### PR TITLE
tegra: Fix pushbufs list order

### DIFF
--- a/tegra/pushbuf.c
+++ b/tegra/pushbuf.c
@@ -71,7 +71,7 @@ int drm_tegra_pushbuf_new(struct drm_tegra_pushbuf **pushbufp,
 	pushbuf->start = pushbuf->base.ptr = (void*)((char*)ptr + offset);
 	pushbuf->offset = offset;
 
-	DRMLISTADD(&pushbuf->list, &job->pushbufs);
+	DRMLISTADDTAIL(&pushbuf->list, &job->pushbufs);
 	job->num_pushbufs++;
 
 	*pushbufp = &pushbuf->base;


### PR DESCRIPTION
It was inverted, causing a failure on a job submission if there is more
than one pushbuf contained in the job.

Signed-off-by: Dmitry Osipenko <digetx@gmail.com>