### PR TITLE
tegra: Initialize jobs syncpoint to the channels one

### DIFF
--- a/tegra/job.c
+++ b/tegra/job.c
@@ -64,6 +64,7 @@ int drm_tegra_job_new(struct drm_tegra_job **jobp,
 
 	DRMINITLISTHEAD(&job->pushbufs);
 	job->channel = channel;
+	job->syncpt = channel->syncpt;
 
 	*jobp = job;
 


### PR DESCRIPTION
The jobs syncpot initialization is absent, so the syncpoint ID 0 is used
regardless of the channels client. That's not good for the case of
multiple channels working simultaneously.

Signed-off-by: Dmitry Osipenko <digetx@gmail.com>