### PR TITLE
Restore old functionality + some new

### DIFF
--- a/tegra/Makefile.am
+++ b/tegra/Makefile.am
@@ -4,7 +4,8 @@ AM_CPPFLAGS = \
 
 AM_CFLAGS = \
 	@PTHREADSTUBS_CFLAGS@ \
-	$(WARN_CFLAGS)
+	$(WARN_CFLAGS) \
+	$(VALGRIND_CFLAGS)
 
 libdrm_tegra_ladir = $(libdir)
 libdrm_tegra_la_LTLIBRARIES = libdrm_tegra.la
@@ -17,7 +18,8 @@ libdrm_tegra_la_SOURCES = \
 	job.c \
 	private.h \
 	pushbuf.c \
-	tegra.c
+	tegra.c \
+	tegra_bo_cache.c
 
 libdrm_tegraincludedir = ${includedir}/libdrm
 libdrm_tegrainclude_HEADERS = tegra.h

--- a/tegra/channel.c
+++ b/tegra/channel.c
@@ -29,7 +29,7 @@
 #include <errno.h>
 #include <string.h>
 
-#include <sys/ioctl.h>
+#include <xf86drm.h>
 
 #include "private.h"
 
@@ -43,7 +43,7 @@ static int drm_tegra_channel_setup(struct drm_tegra_channel *channel)
 	args.context = channel->context;
 	args.index = 0;
 
-	err = ioctl(drm->fd, DRM_IOCTL_TEGRA_GET_SYNCPT, &args);
+	err = drmIoctl(drm->fd, DRM_IOCTL_TEGRA_GET_SYNCPT, &args);
 	if (err < 0)
 		return -errno;
 
@@ -83,7 +83,7 @@ int drm_tegra_channel_open(struct drm_tegra_channel **channelp,
 	memset(&args, 0, sizeof(args));
 	args.client = class;
 
-	err = ioctl(drm->fd, DRM_IOCTL_TEGRA_OPEN_CHANNEL, &args);
+	err = drmIoctl(drm->fd, DRM_IOCTL_TEGRA_OPEN_CHANNEL, &args);
 	if (err < 0) {
 		free(channel);
 		return -errno;
@@ -117,7 +117,7 @@ int drm_tegra_channel_close(struct drm_tegra_channel *channel)
 	memset(&args, 0, sizeof(args));
 	args.context = channel->context;
 
-	err = ioctl(drm->fd, DRM_IOCTL_TEGRA_CLOSE_CHANNEL, &args);
+	err = drmIoctl(drm->fd, DRM_IOCTL_TEGRA_CLOSE_CHANNEL, &args);
 	if (err < 0)
 		return -errno;
 

--- a/tegra/fence.c
+++ b/tegra/fence.c
@@ -29,7 +29,7 @@
 #include <errno.h>
 #include <string.h>
 
-#include <sys/ioctl.h>
+#include <xf86drm.h>
 
 #include "private.h"
 
@@ -44,17 +44,9 @@ int drm_tegra_fence_wait_timeout(struct drm_tegra_fence *fence,
 	args.thresh = fence->value;
 	args.timeout = timeout;
 
-	while (true) {
-		err = ioctl(fence->drm->fd, DRM_IOCTL_TEGRA_SYNCPT_WAIT, &args);
-		if (err < 0) {
-			if (errno == EINTR)
-				continue;
-
-			return -errno;
-		}
-
-		break;
-	}
+	err = drmIoctl(fence->drm->fd, DRM_IOCTL_TEGRA_SYNCPT_WAIT, &args);
+	if (err < 0)
+		return -errno;
 
 	return 0;
 }

--- a/tegra/job.c
+++ b/tegra/job.c
@@ -30,7 +30,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <sys/ioctl.h>
+#include <xf86drm.h>
 
 #include "private.h"
 
@@ -157,7 +157,7 @@ int drm_tegra_job_submit(struct drm_tegra_job *job,
 	args.relocs = (uintptr_t)job->relocs;
 	args.waitchks = 0;
 
-	err = ioctl(drm->fd, DRM_IOCTL_TEGRA_SUBMIT, &args);
+	err = drmIoctl(drm->fd, DRM_IOCTL_TEGRA_SUBMIT, &args);
 	if (err < 0) {
 		free(syncpts);
 		free(fence);

--- a/tegra/pushbuf.c
+++ b/tegra/pushbuf.c
@@ -167,6 +167,10 @@ int drm_tegra_pushbuf_relocate(struct drm_tegra_pushbuf *pushbuf,
 	struct drm_tegra_reloc reloc;
 	int err;
 
+	err = drm_tegra_pushbuf_prepare(pushbuf, 1);
+	if (err < 0)
+		return err;
+
 	memset(&reloc, 0, sizeof(reloc));
 	reloc.cmdbuf.handle = priv->bo->handle;
 	reloc.cmdbuf.offset = drm_tegra_pushbuf_get_offset(pushbuf);

--- a/tegra/pushbuf.c
+++ b/tegra/pushbuf.c
@@ -99,8 +99,10 @@ int drm_tegra_pushbuf_free(struct drm_tegra_pushbuf *pushbuf)
 
 	drm_tegra_bo_unmap(priv->bo);
 
-	DRMLISTFOREACHENTRYSAFE(bo, tmp, &priv->bos, list)
+	DRMLISTFOREACHENTRYSAFE(bo, tmp, &priv->bos, push_list) {
+		DRMLISTDEL(&priv->bo->push_list);
 		drm_tegra_bo_unref(priv->bo);
+	}
 
 	DRMLISTDEL(&priv->list);
 	free(priv);
@@ -149,7 +151,7 @@ int drm_tegra_pushbuf_prepare(struct drm_tegra_pushbuf *pushbuf,
 		return err;
 	}
 
-	DRMLISTADD(&bo->list, &priv->bos);
+	DRMLISTADD(&bo->push_list, &priv->bos);
 
 	priv->start = priv->base.ptr = ptr;
 	priv->end = priv->start + bo->size;

--- a/tegra/tegra-symbol-check
+++ b/tegra/tegra-symbol-check
@@ -40,6 +40,8 @@ drm_tegra_fence_wait_timeou
 drm_tegra_fence_free
 drm_tegra_bo_get_name
 drm_tegra_bo_from_name
+drm_tegra_bo_from_dmabuf
+drm_tegra_bo_to_dmabuf
 EOF
 done)
 

--- a/tegra/tegra.c
+++ b/tegra/tegra.c
@@ -434,3 +434,42 @@ int drm_tegra_bo_from_name(struct drm_tegra_bo **bop, struct drm_tegra *drm,
 
 	return 0;
 }
+
+int drm_tegra_bo_to_dmabuf(struct drm_tegra_bo *bo, uint32_t *handle)
+{
+	struct drm_tegra *drm = bo->drm;
+	int prime_fd;
+	int err;
+
+	err = drmPrimeHandleToFD(drm->fd, bo->handle, DRM_CLOEXEC, &prime_fd);
+	if (err)
+		return err;
+
+	bo->reuse = false;
+
+	*handle = prime_fd;
+
+	return 0;
+}
+
+int drm_tegra_bo_from_dmabuf(struct drm_tegra_bo **bop, struct drm_tegra *drm,
+			     int fd, uint32_t flags)
+{
+	uint32_t handle;
+	uint32_t size;
+	int err;
+
+	err = drmPrimeFDToHandle(drm->fd, fd, &handle);
+	if (err)
+		return err;
+
+	/* lseek() to get bo size */
+	size = lseek(fd, 0, SEEK_END);
+	lseek(fd, 0, SEEK_CUR);
+
+	err = drm_tegra_bo_wrap(bop, drm, handle, flags, size);
+	if (err)
+		return err;
+
+	return 0;
+}

--- a/tegra/tegra.c
+++ b/tegra/tegra.c
@@ -160,6 +160,7 @@ int drm_tegra_bo_wrap(struct drm_tegra_bo **bop, struct drm_tegra *drm,
 	if (!bo)
 		return -ENOMEM;
 
+	DRMINITLISTHEAD(&bo->list);
 	atomic_set(&bo->ref, 1);
 	bo->handle = handle;
 	bo->flags = flags;

--- a/tegra/tegra.c
+++ b/tegra/tegra.c
@@ -28,6 +28,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <pthread.h>
 #include <string.h>
 #include <unistd.h>
 
@@ -39,11 +40,16 @@
 
 #include "private.h"
 
-static int drm_tegra_bo_free(struct drm_tegra_bo *bo)
+drm_private pthread_mutex_t table_lock = PTHREAD_MUTEX_INITIALIZER;
+
+drm_private int drm_tegra_bo_free(struct drm_tegra_bo *bo)
 {
 	struct drm_tegra *drm = bo->drm;
 	struct drm_gem_close args;
 	int err;
+
+	if (bo->reuse)
+		VG_BO_FREE(bo);
 
 	if (bo->map)
 		munmap(bo->map, bo->size);
@@ -53,7 +59,7 @@ static int drm_tegra_bo_free(struct drm_tegra_bo *bo)
 
 	err = drmIoctl(drm->fd, DRM_IOCTL_GEM_CLOSE, &args);
 
-	DRMLISTDEL(&bo->list);
+	DRMLISTDEL(&bo->bo_list);
 	free(bo);
 
 	return err;
@@ -72,6 +78,8 @@ static int drm_tegra_wrap(struct drm_tegra **drmp, int fd, bool close)
 
 	drm->close = close;
 	drm->fd = fd;
+
+	drm_tegra_bo_cache_init(&drm->bo_cache, false);
 
 	*drmp = drm;
 
@@ -106,6 +114,8 @@ void drm_tegra_close(struct drm_tegra *drm)
 	if (drm->close)
 		close(drm->fd);
 
+	drm_tegra_bo_cache_cleanup(&drm->bo_cache, 0);
+
 	free(drm);
 }
 
@@ -119,12 +129,18 @@ int drm_tegra_bo_new(struct drm_tegra_bo **bop, struct drm_tegra *drm,
 	if (!drm || size == 0 || !bop)
 		return -EINVAL;
 
+	bo = drm_tegra_bo_cache_alloc(&drm->bo_cache, &size, flags);
+	if (bo)
+		goto out;
+
 	bo = calloc(1, sizeof(*bo));
 	if (!bo)
 		return -ENOMEM;
 
-	DRMINITLISTHEAD(&bo->list);
+	DRMINITLISTHEAD(&bo->push_list);
+	DRMINITLISTHEAD(&bo->bo_list);
 	atomic_set(&bo->ref, 1);
+	bo->reuse = true;
 	bo->flags = flags;
 	bo->size = size;
 	bo->drm = drm;
@@ -143,6 +159,8 @@ int drm_tegra_bo_new(struct drm_tegra_bo **bop, struct drm_tegra *drm,
 
 	bo->handle = args.handle;
 
+	VG_BO_ALLOC(bo);
+out:
 	*bop = bo;
 
 	return 0;
@@ -160,7 +178,8 @@ int drm_tegra_bo_wrap(struct drm_tegra_bo **bop, struct drm_tegra *drm,
 	if (!bo)
 		return -ENOMEM;
 
-	DRMINITLISTHEAD(&bo->list);
+	DRMINITLISTHEAD(&bo->push_list);
+	DRMINITLISTHEAD(&bo->bo_list);
 	atomic_set(&bo->ref, 1);
 	bo->handle = handle;
 	bo->flags = flags;
@@ -182,13 +201,23 @@ struct drm_tegra_bo *drm_tegra_bo_ref(struct drm_tegra_bo *bo)
 
 int drm_tegra_bo_unref(struct drm_tegra_bo *bo)
 {
-	int err = -EBUSY;
+	struct drm_tegra *drm;
+	int err = 0;
 
 	if (!bo)
 		return -EINVAL;
 
-	if (atomic_dec_and_test(&bo->ref))
+	if (!atomic_dec_and_test(&bo->ref))
+		return 0;
+
+	drm = bo->drm;
+
+	pthread_mutex_lock(&table_lock);
+
+	if (!bo->reuse || (drm_tegra_bo_cache_free(&drm->bo_cache, bo) != 0))
 		err = drm_tegra_bo_free(bo);
+
+	pthread_mutex_unlock(&table_lock);
 
 	return err;
 }
@@ -368,6 +397,7 @@ int drm_tegra_bo_get_name(struct drm_tegra_bo *bo, uint32_t *name)
 			return -errno;
 
 		bo->name = args.name;
+		bo->reuse = false;
 	}
 
 	*name = bo->name;

--- a/tegra/tegra.c
+++ b/tegra/tegra.c
@@ -39,10 +39,11 @@
 
 #include "private.h"
 
-static void drm_tegra_bo_free(struct drm_tegra_bo *bo)
+static int drm_tegra_bo_free(struct drm_tegra_bo *bo)
 {
 	struct drm_tegra *drm = bo->drm;
 	struct drm_gem_close args;
+	int err;
 
 	if (bo->map)
 		munmap(bo->map, bo->size);
@@ -50,10 +51,12 @@ static void drm_tegra_bo_free(struct drm_tegra_bo *bo)
 	memset(&args, 0, sizeof(args));
 	args.handle = bo->handle;
 
-	drmIoctl(drm->fd, DRM_IOCTL_GEM_CLOSE, &args);
+	err = drmIoctl(drm->fd, DRM_IOCTL_GEM_CLOSE, &args);
 
 	DRMLISTDEL(&bo->list);
 	free(bo);
+
+	return err;
 }
 
 static int drm_tegra_wrap(struct drm_tegra **drmp, int fd, bool close)
@@ -176,10 +179,17 @@ struct drm_tegra_bo *drm_tegra_bo_ref(struct drm_tegra_bo *bo)
 	return bo;
 }
 
-void drm_tegra_bo_unref(struct drm_tegra_bo *bo)
+int drm_tegra_bo_unref(struct drm_tegra_bo *bo)
 {
-	if (bo && atomic_dec_and_test(&bo->ref))
-		drm_tegra_bo_free(bo);
+	int err = -EBUSY;
+
+	if (!bo)
+		return -EINVAL;
+
+	if (atomic_dec_and_test(&bo->ref))
+		err = drm_tegra_bo_free(bo);
+
+	return err;
 }
 
 int drm_tegra_bo_get_handle(struct drm_tegra_bo *bo, uint32_t *handle)

--- a/tegra/tegra.h
+++ b/tegra/tegra.h
@@ -68,6 +68,10 @@ int drm_tegra_bo_get_name(struct drm_tegra_bo *bo, uint32_t *name);
 int drm_tegra_bo_from_name(struct drm_tegra_bo **bop, struct drm_tegra *drm,
 			   uint32_t name, uint32_t flags);
 
+int drm_tegra_bo_to_dmabuf(struct drm_tegra_bo *bo, uint32_t *handle);
+int drm_tegra_bo_from_dmabuf(struct drm_tegra_bo **bop, struct drm_tegra *drm,
+			     int fd, uint32_t flags);
+
 struct drm_tegra_channel;
 struct drm_tegra_job;
 

--- a/tegra/tegra.h
+++ b/tegra/tegra.h
@@ -46,7 +46,7 @@ int drm_tegra_bo_new(struct drm_tegra_bo **bop, struct drm_tegra *drm,
 int drm_tegra_bo_wrap(struct drm_tegra_bo **bop, struct drm_tegra *drm,
 		      uint32_t handle, uint32_t flags, uint32_t size);
 struct drm_tegra_bo *drm_tegra_bo_ref(struct drm_tegra_bo *bo);
-void drm_tegra_bo_unref(struct drm_tegra_bo *bo);
+int drm_tegra_bo_unref(struct drm_tegra_bo *bo);
 int drm_tegra_bo_get_handle(struct drm_tegra_bo *bo, uint32_t *handle);
 int drm_tegra_bo_map(struct drm_tegra_bo *bo, void **ptr);
 int drm_tegra_bo_unmap(struct drm_tegra_bo *bo);

--- a/tegra/tegra_bo_cache.c
+++ b/tegra/tegra_bo_cache.c
@@ -1,0 +1,211 @@
+/*
+ * Copyright (C) 2016 Rob Clark <robclark@freedesktop.org>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Authors:
+ *    Rob Clark <robclark@freedesktop.org>
+ */
+
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#include <assert.h>
+#include <pthread.h>
+
+#include "private.h"
+
+drm_private extern pthread_mutex_t table_lock;
+
+static void
+add_bucket(struct drm_tegra_bo_cache *cache, int size)
+{
+	unsigned int i = cache->num_buckets;
+
+	assert(i < ARRAY_SIZE(cache->cache_bucket));
+
+	DRMINITLISTHEAD(&cache->cache_bucket[i].list);
+	cache->cache_bucket[i].size = size;
+	cache->num_buckets++;
+}
+
+/**
+ * @coarse: if true, only power-of-two bucket sizes, otherwise
+ *    fill in for a bit smoother size curve..
+ */
+drm_private void
+drm_tegra_bo_cache_init(struct drm_tegra_bo_cache *cache, bool course)
+{
+	unsigned long size, cache_max_size = 64 * 1024 * 1024;
+
+	/* OK, so power of two buckets was too wasteful of memory.
+	 * Give 3 other sizes between each power of two, to hopefully
+	 * cover things accurately enough.  (The alternative is
+	 * probably to just go for exact matching of sizes, and assume
+	 * that for things like composited window resize the tiled
+	 * width/height alignment and rounding of sizes to pages will
+	 * get us useful cache hit rates anyway)
+	 */
+	add_bucket(cache, 4096);
+	add_bucket(cache, 4096 * 2);
+	if (!course)
+		add_bucket(cache, 4096 * 3);
+
+	/* Initialize the linked lists for BO reuse cache. */
+	for (size = 4 * 4096; size <= cache_max_size; size *= 2) {
+		add_bucket(cache, size);
+		if (!course) {
+			add_bucket(cache, size + size * 1 / 4);
+			add_bucket(cache, size + size * 2 / 4);
+			add_bucket(cache, size + size * 3 / 4);
+		}
+	}
+}
+
+/* Frees older cached buffers.  Called under table_lock */
+drm_private void
+drm_tegra_bo_cache_cleanup(struct drm_tegra_bo_cache *cache, time_t time)
+{
+	int i;
+
+	if (cache->time == time)
+		return;
+
+	for (i = 0; i < cache->num_buckets; i++) {
+		struct drm_tegra_bo_bucket *bucket = &cache->cache_bucket[i];
+		struct drm_tegra_bo *bo;
+
+		while (!DRMLISTEMPTY(&bucket->list)) {
+			bo = DRMLISTENTRY(struct drm_tegra_bo,
+					  bucket->list.next, bo_list);
+
+			/* keep things in cache for at least 1 second: */
+			if (time && ((time - bo->free_time) <= 1))
+				break;
+
+			VG_BO_OBTAIN(bo);
+			DRMLISTDEL(&bo->bo_list);
+			drm_tegra_bo_free(bo);
+		}
+	}
+
+	cache->time = time;
+}
+
+static struct drm_tegra_bo_bucket * get_bucket(struct drm_tegra_bo_cache *cache,
+					       uint32_t size)
+{
+	int i;
+
+	/* hmm, this is what intel does, but I suppose we could calculate our
+	 * way to the correct bucket size rather than looping..
+	 */
+	for (i = 0; i < cache->num_buckets; i++) {
+		struct drm_tegra_bo_bucket *bucket = &cache->cache_bucket[i];
+		if (bucket->size >= size) {
+			return bucket;
+		}
+	}
+
+	return NULL;
+}
+
+static int is_idle(struct drm_tegra_bo *bo)
+{
+	/* TODO implement drm_tegra_bo_cpu_prep() */
+	return 1;
+}
+
+static struct drm_tegra_bo *find_in_bucket(struct drm_tegra_bo_bucket *bucket,
+					   uint32_t flags)
+{
+	struct drm_tegra_bo *bo = NULL;
+
+	/* TODO .. if we had an ALLOC_FOR_RENDER flag like intel, we could
+	 * skip the busy check.. if it is only going to be a render target
+	 * then we probably don't need to stall..
+	 *
+	 * NOTE that intel takes ALLOC_FOR_RENDER bo's from the list tail
+	 * (MRU, since likely to be in GPU cache), rather than head (LRU)..
+	 */
+	pthread_mutex_lock(&table_lock);
+	if (!DRMLISTEMPTY(&bucket->list)) {
+		bo = DRMLISTENTRY(struct drm_tegra_bo, bucket->list.next,
+				  bo_list);
+		/* TODO check for compatible flags? */
+		if (is_idle(bo)) {
+			DRMLISTDEL(&bo->bo_list);
+		} else {
+			bo = NULL;
+		}
+	}
+	pthread_mutex_unlock(&table_lock);
+
+	return bo;
+}
+
+/* NOTE: size is potentially rounded up to bucket size: */
+drm_private struct drm_tegra_bo *
+drm_tegra_bo_cache_alloc(struct drm_tegra_bo_cache *cache,
+			 uint32_t *size, uint32_t flags)
+{
+	struct drm_tegra_bo *bo = NULL;
+	struct drm_tegra_bo_bucket *bucket;
+
+	*size = align(*size, 4096);
+	bucket = get_bucket(cache, *size);
+
+	/* see if we can be green and recycle: */
+	if (bucket) {
+		*size = bucket->size;
+		bo = find_in_bucket(bucket, flags);
+		if (bo) {
+			VG_BO_OBTAIN(bo);
+			atomic_set(&bo->ref, 1);
+			return bo;
+		}
+	}
+
+	return NULL;
+}
+
+drm_private int
+drm_tegra_bo_cache_free(struct drm_tegra_bo_cache *cache,
+			struct drm_tegra_bo *bo)
+{
+	struct drm_tegra_bo_bucket *bucket = get_bucket(cache, bo->size);
+
+	/* see if we can be green and recycle: */
+	if (bucket) {
+		struct timespec time;
+
+		clock_gettime(CLOCK_MONOTONIC, &time);
+
+		bo->free_time = time.tv_sec;
+		VG_BO_RELEASE(bo);
+		DRMLISTADDTAIL(&bo->bo_list, &bucket->list);
+		drm_tegra_bo_cache_cleanup(cache, time.tv_sec);
+
+		return 0;
+	}
+
+	return -1;
+}


### PR DESCRIPTION
I've rebased the libdrm on the @thierryreding recent work from freedesktop.org, the old fixes still apply here and some new were added, new features were added as well (BO caching, dmabuf functions). The BO caching gives a significant performance boost to opentegra, drm_tegra_bo_to_dmabuf was tested by VDPAU driver.