### PR TITLE
tegra: Correct pushbufs BO mmap'ing balance and free'ing

### DIFF
--- a/tegra/pushbuf.c
+++ b/tegra/pushbuf.c
@@ -61,6 +61,9 @@ int drm_tegra_pushbuf_queue(struct drm_tegra_pushbuf_private *pushbuf)
 	cmdbuf.handle = pushbuf->bo->handle;
 	cmdbuf.offset = 0;
 
+	/* maintain mmap refcount balance upon pushbuf free'ing */
+	pushbuf->bo = NULL;
+
 	err = drm_tegra_job_add_cmdbuf(pushbuf->job, &cmdbuf);
 	if (err < 0)
 		return err;
@@ -100,8 +103,8 @@ int drm_tegra_pushbuf_free(struct drm_tegra_pushbuf *pushbuf)
 	drm_tegra_bo_unmap(priv->bo);
 
 	DRMLISTFOREACHENTRYSAFE(bo, tmp, &priv->bos, push_list) {
-		DRMLISTDEL(&priv->bo->push_list);
-		drm_tegra_bo_unref(priv->bo);
+		DRMLISTDEL(&bo->push_list);
+		drm_tegra_bo_unref(bo);
 	}
 
 	DRMLISTDEL(&priv->list);


### PR DESCRIPTION
Valgring detects false positive memory leak due to a BO mmap'ing
disbalance caused by a latest-appended pushbufs BO double unmapping
in drm_tegra_pushbuf_queue() and then in drm_tegra_pushbuf_free().

Only the latest-appended pushbufs BO is destroyed in pushbuf_free(),
obviously that's an accidental copy-paste bug.

Signed-off-by: Dmitry Osipenko <digetx@gmail.com>