### PR TITLE
Hashtable lookups and some fixes

### DIFF
--- a/tegra/private.h
+++ b/tegra/private.h
@@ -65,6 +65,17 @@ struct drm_tegra_bo_cache {
 };
 
 struct drm_tegra {
+	/* tables to keep track of bo's, to avoid "evil-twin" buffer objects:
+	 *
+	 *   handle_table: maps handle to fd_bo
+	 *   name_table: maps flink name to fd_bo
+	 *
+	 * We end up needing two tables, because DRM_IOCTL_GEM_OPEN always
+	 * returns a new handle.  So we need to figure out if the bo is already
+	 * open in the process first, before calling gem-open.
+	 */
+	void *handle_table, *name_table;
+
 	struct drm_tegra_bo_cache bo_cache;
 	bool close;
 	int fd;

--- a/tegra/pushbuf.c
+++ b/tegra/pushbuf.c
@@ -94,12 +94,13 @@ int drm_tegra_pushbuf_new(struct drm_tegra_pushbuf **pushbufp,
 
 int drm_tegra_pushbuf_free(struct drm_tegra_pushbuf *pushbuf)
 {
-	struct drm_tegra_pushbuf_private *priv = drm_tegra_pushbuf(pushbuf);
+	struct drm_tegra_pushbuf_private *priv;
 	struct drm_tegra_bo *bo, *tmp;
 
 	if (!pushbuf)
 		return -EINVAL;
 
+	priv = drm_tegra_pushbuf(pushbuf);
 	drm_tegra_bo_unmap(priv->bo);
 
 	DRMLISTFOREACHENTRYSAFE(bo, tmp, &priv->bos, push_list) {

--- a/tegra/tegra.c
+++ b/tegra/tegra.c
@@ -276,31 +276,31 @@ unlock:
 
 int drm_tegra_bo_unmap(struct drm_tegra_bo *bo)
 {
+	int err = 0;
+
 	if (!bo)
 		return -EINVAL;
 
 	pthread_mutex_lock(&table_lock);
 
-	if (!bo->map) {
-		pthread_mutex_unlock(&table_lock);
-		return 0;
-	}
+	if (!bo->map)
+		goto unlock;
 
-	if (--bo->mmap_ref > 0) {
-		pthread_mutex_unlock(&table_lock);
-		return 0;
-	}
+	if (--bo->mmap_ref > 0)
+		goto unlock;
 
-	if (munmap(bo->map, bo->size)) {
-		pthread_mutex_unlock(&table_lock);
-		return -errno;
+	err = munmap(bo->map, bo->size);
+	if (err < 0) {
+		err = -errno;
+		goto unlock;
 	}
-
-	pthread_mutex_unlock(&table_lock);
 
 	bo->map = NULL;
 
-	return 0;
+unlock:
+	pthread_mutex_unlock(&table_lock);
+
+	return err;
 }
 
 int drm_tegra_bo_get_flags(struct drm_tegra_bo *bo, uint32_t *flags)

--- a/tegra/tegra.c
+++ b/tegra/tegra.c
@@ -40,6 +40,23 @@
 
 drm_private pthread_mutex_t table_lock = PTHREAD_MUTEX_INITIALIZER;
 
+/* lookup a buffer, call with table_lock mutex locked */
+static struct drm_tegra_bo * lookup_bo(void *table, uint32_t key)
+{
+	struct drm_tegra_bo *bo;
+
+	if (drmHashLookup(table, key, (void **)&bo))
+		return NULL;
+
+	/* found, increment reference count */
+	atomic_inc(&bo->ref);
+
+	/* don't break the bucket if this BO was found in one */
+	DRMLISTDELINIT(&bo->bo_list);
+
+	return bo;
+}
+
 drm_private int drm_tegra_bo_free(struct drm_tegra_bo *bo)
 {
 	struct drm_tegra *drm = bo->drm;
@@ -50,6 +67,11 @@ drm_private int drm_tegra_bo_free(struct drm_tegra_bo *bo)
 
 	if (bo->map)
 		munmap(bo->map, bo->size);
+
+	if (bo->name)
+		drmHashDelete(drm->name_table, bo->name);
+
+	drmHashDelete(drm->handle_table, bo->handle);
 
 	memset(&args, 0, sizeof(args));
 	args.handle = bo->handle;
@@ -76,6 +98,11 @@ static int drm_tegra_wrap(struct drm_tegra **drmp, int fd, bool close)
 	drm->fd = fd;
 
 	drm_tegra_bo_cache_init(&drm->bo_cache, false);
+	drm->handle_table = drmHashCreate();
+	drm->name_table = drmHashCreate();
+
+	if (!drm->handle_table || !drm->name_table)
+		return -ENOMEM;
 
 	*drmp = drm;
 
@@ -108,6 +135,8 @@ void drm_tegra_close(struct drm_tegra *drm)
 		return;
 
 	drm_tegra_bo_cache_cleanup(&drm->bo_cache, 0);
+	drmHashDestroy(drm->handle_table);
+	drmHashDestroy(drm->name_table);
 
 	if (drm->close)
 		close(drm->fd);
@@ -156,6 +185,9 @@ int drm_tegra_bo_new(struct drm_tegra_bo **bop, struct drm_tegra *drm,
 	bo->handle = args.handle;
 
 	VG_BO_ALLOC(bo);
+
+	/* add ourselves into the handle table */
+	drmHashInsert(drm->handle_table, args.handle, bo);
 out:
 	*bop = bo;
 
@@ -398,6 +430,8 @@ int drm_tegra_bo_set_tiling(struct drm_tegra_bo *bo,
 
 int drm_tegra_bo_get_name(struct drm_tegra_bo *bo, uint32_t *name)
 {
+	struct drm_tegra *drm = bo->drm;
+
 	if (!bo || !name)
 		return -EINVAL;
 
@@ -408,12 +442,17 @@ int drm_tegra_bo_get_name(struct drm_tegra_bo *bo, uint32_t *name)
 		memset(&args, 0, sizeof(args));
 		args.handle = bo->handle;
 
-		err = drmIoctl(bo->drm->fd, DRM_IOCTL_GEM_FLINK, &args);
+		err = drmIoctl(drm->fd, DRM_IOCTL_GEM_FLINK, &args);
 		if (err < 0)
 			return -errno;
 
+		pthread_mutex_lock(&table_lock);
+
+		drmHashInsert(drm->name_table, args.name, bo);
 		bo->name = args.name;
 		bo->reuse = false;
+
+		pthread_mutex_unlock(&table_lock);
 	}
 
 	*name = bo->name;
@@ -425,15 +464,25 @@ int drm_tegra_bo_from_name(struct drm_tegra_bo **bop, struct drm_tegra *drm,
 			   uint32_t name, uint32_t flags)
 {
 	struct drm_gem_open args;
+	struct drm_tegra_bo *dup;
 	struct drm_tegra_bo *bo;
-	int err;
+	int err = 0;
 
 	if (!drm || !name || !bop)
 		return -EINVAL;
 
+	pthread_mutex_lock(&table_lock);
+
+	/* check name table first, to see if BO is already open */
+	bo = lookup_bo(drm->name_table, name);
+	if (bo)
+		goto unlock;
+
 	bo = calloc(1, sizeof(*bo));
-	if (!bo)
-		return -ENOMEM;
+	if (!bo) {
+		err = -ENOMEM;
+		goto unlock;
+	}
 
 	memset(&args, 0, sizeof(args));
 	args.name = name;
@@ -441,9 +490,19 @@ int drm_tegra_bo_from_name(struct drm_tegra_bo **bop, struct drm_tegra *drm,
 	err = drmIoctl(drm->fd, DRM_IOCTL_GEM_OPEN, &args);
 	if (err < 0) {
 		free(bo);
-		return -errno;
+		bo = NULL;
+		goto unlock;
 	}
 
+	/* check handle table second, to see if BO is already open */
+	dup = lookup_bo(drm->handle_table, args.handle);
+	if (dup) {
+		free(bo);
+		bo = dup;
+		goto unlock;
+	}
+
+	drmHashInsert(drm->name_table, name, bo);
 	atomic_set(&bo->ref, 1);
 	bo->name = name;
 	bo->handle = args.handle;
@@ -453,9 +512,12 @@ int drm_tegra_bo_from_name(struct drm_tegra_bo **bop, struct drm_tegra *drm,
 
 	VG_BO_ALLOC(bo);
 
+unlock:
+	pthread_mutex_unlock(&table_lock);
+
 	*bop = bo;
 
-	return 0;
+	return err;
 }
 
 int drm_tegra_bo_to_dmabuf(struct drm_tegra_bo *bo, uint32_t *handle)
@@ -481,6 +543,7 @@ int drm_tegra_bo_to_dmabuf(struct drm_tegra_bo *bo, uint32_t *handle)
 int drm_tegra_bo_from_dmabuf(struct drm_tegra_bo **bop, struct drm_tegra *drm,
 			     int fd, uint32_t flags)
 {
+	struct drm_tegra_bo *dup;
 	struct drm_tegra_bo *bo;
 	uint32_t handle;
 	uint32_t size;
@@ -489,14 +552,27 @@ int drm_tegra_bo_from_dmabuf(struct drm_tegra_bo **bop, struct drm_tegra *drm,
 	if (!drm || !bop)
 		return -EINVAL;
 
+	pthread_mutex_lock(&table_lock);
+
 	bo = calloc(1, sizeof(*bo));
-	if (!bo)
-		return -ENOMEM;
+	if (!bo) {
+		err = -ENOMEM;
+		goto unlock;
+	}
 
 	err = drmPrimeFDToHandle(drm->fd, fd, &handle);
 	if (err) {
 		free(bo);
-		return err;
+		bo = NULL;
+		goto unlock;
+	}
+
+	/* check handle table to see if BO is already open */
+	dup = lookup_bo(drm->handle_table, handle);
+	if (dup) {
+		free(bo);
+		bo = dup;
+		goto unlock;
 	}
 
 	/* lseek() to get bo size */
@@ -510,6 +586,9 @@ int drm_tegra_bo_from_dmabuf(struct drm_tegra_bo **bop, struct drm_tegra *drm,
 	bo->drm = drm;
 
 	VG_BO_ALLOC(bo);
+
+unlock:
+	pthread_mutex_unlock(&table_lock);
 
 	*bop = bo;
 

--- a/tegra/tegra.c
+++ b/tegra/tegra.c
@@ -231,7 +231,6 @@ struct drm_tegra_bo *drm_tegra_bo_ref(struct drm_tegra_bo *bo)
 
 int drm_tegra_bo_unref(struct drm_tegra_bo *bo)
 {
-	struct drm_tegra *drm;
 	int err = 0;
 
 	if (!bo)
@@ -240,11 +239,9 @@ int drm_tegra_bo_unref(struct drm_tegra_bo *bo)
 	if (!atomic_dec_and_test(&bo->ref))
 		return 0;
 
-	drm = bo->drm;
-
 	pthread_mutex_lock(&table_lock);
 
-	if (!bo->reuse || (drm_tegra_bo_cache_free(&drm->bo_cache, bo) != 0))
+	if (!bo->reuse || drm_tegra_bo_cache_free(&bo->drm->bo_cache, bo))
 		err = drm_tegra_bo_free(bo);
 
 	pthread_mutex_unlock(&table_lock);
@@ -264,8 +261,10 @@ int drm_tegra_bo_get_handle(struct drm_tegra_bo *bo, uint32_t *handle)
 
 int drm_tegra_bo_map(struct drm_tegra_bo *bo, void **ptr)
 {
-	struct drm_tegra *drm = bo->drm;
 	int err;
+
+	if (!bo)
+		return -EINVAL;
 
 	pthread_mutex_lock(&table_lock);
 
@@ -275,7 +274,7 @@ int drm_tegra_bo_map(struct drm_tegra_bo *bo, void **ptr)
 		memset(&args, 0, sizeof(args));
 		args.handle = bo->handle;
 
-		err = drmCommandWriteRead(drm->fd, DRM_TEGRA_GEM_MMAP, &args,
+		err = drmCommandWriteRead(bo->drm->fd, DRM_TEGRA_GEM_MMAP, &args,
 					  sizeof(args));
 		if (err < 0) {
 			err = -errno;
@@ -285,7 +284,7 @@ int drm_tegra_bo_map(struct drm_tegra_bo *bo, void **ptr)
 		bo->offset = args.offset;
 
 		bo->map = mmap(0, bo->size, PROT_READ | PROT_WRITE, MAP_SHARED,
-			       drm->fd, bo->offset);
+			       bo->drm->fd, bo->offset);
 		if (bo->map == MAP_FAILED) {
 			bo->map = NULL;
 			err = -errno;
@@ -338,7 +337,6 @@ unlock:
 int drm_tegra_bo_get_flags(struct drm_tegra_bo *bo, uint32_t *flags)
 {
 	struct drm_tegra_gem_get_flags args;
-	struct drm_tegra *drm = bo->drm;
 	int err;
 
 	if (!bo)
@@ -347,7 +345,7 @@ int drm_tegra_bo_get_flags(struct drm_tegra_bo *bo, uint32_t *flags)
 	memset(&args, 0, sizeof(args));
 	args.handle = bo->handle;
 
-	err = drmCommandWriteRead(drm->fd, DRM_TEGRA_GEM_GET_FLAGS, &args,
+	err = drmCommandWriteRead(bo->drm->fd, DRM_TEGRA_GEM_GET_FLAGS, &args,
 				  sizeof(args));
 	if (err < 0)
 		return -errno;
@@ -361,7 +359,6 @@ int drm_tegra_bo_get_flags(struct drm_tegra_bo *bo, uint32_t *flags)
 int drm_tegra_bo_set_flags(struct drm_tegra_bo *bo, uint32_t flags)
 {
 	struct drm_tegra_gem_get_flags args;
-	struct drm_tegra *drm = bo->drm;
 	int err;
 
 	if (!bo)
@@ -371,7 +368,7 @@ int drm_tegra_bo_set_flags(struct drm_tegra_bo *bo, uint32_t flags)
 	args.handle = bo->handle;
 	args.flags = flags;
 
-	err = drmCommandWriteRead(drm->fd, DRM_TEGRA_GEM_SET_FLAGS, &args,
+	err = drmCommandWriteRead(bo->drm->fd, DRM_TEGRA_GEM_SET_FLAGS, &args,
 				  sizeof(args));
 	if (err < 0)
 		return -errno;
@@ -383,7 +380,6 @@ int drm_tegra_bo_get_tiling(struct drm_tegra_bo *bo,
 			    struct drm_tegra_bo_tiling *tiling)
 {
 	struct drm_tegra_gem_get_tiling args;
-	struct drm_tegra *drm = bo->drm;
 	int err;
 
 	if (!bo)
@@ -392,7 +388,7 @@ int drm_tegra_bo_get_tiling(struct drm_tegra_bo *bo,
 	memset(&args, 0, sizeof(args));
 	args.handle = bo->handle;
 
-	err = drmCommandWriteRead(drm->fd, DRM_TEGRA_GEM_GET_TILING, &args,
+	err = drmCommandWriteRead(bo->drm->fd, DRM_TEGRA_GEM_GET_TILING, &args,
 				  sizeof(args));
 	if (err < 0)
 		return -errno;
@@ -409,7 +405,6 @@ int drm_tegra_bo_set_tiling(struct drm_tegra_bo *bo,
 			    const struct drm_tegra_bo_tiling *tiling)
 {
 	struct drm_tegra_gem_set_tiling args;
-	struct drm_tegra *drm = bo->drm;
 	int err;
 
 	if (!bo)
@@ -420,7 +415,7 @@ int drm_tegra_bo_set_tiling(struct drm_tegra_bo *bo,
 	args.mode = tiling->mode;
 	args.value = tiling->value;
 
-	err = drmCommandWriteRead(drm->fd, DRM_TEGRA_GEM_SET_TILING, &args,
+	err = drmCommandWriteRead(bo->drm->fd, DRM_TEGRA_GEM_SET_TILING, &args,
 				  sizeof(args));
 	if (err < 0)
 		return -errno;
@@ -430,8 +425,6 @@ int drm_tegra_bo_set_tiling(struct drm_tegra_bo *bo,
 
 int drm_tegra_bo_get_name(struct drm_tegra_bo *bo, uint32_t *name)
 {
-	struct drm_tegra *drm = bo->drm;
-
 	if (!bo || !name)
 		return -EINVAL;
 
@@ -442,13 +435,13 @@ int drm_tegra_bo_get_name(struct drm_tegra_bo *bo, uint32_t *name)
 		memset(&args, 0, sizeof(args));
 		args.handle = bo->handle;
 
-		err = drmIoctl(drm->fd, DRM_IOCTL_GEM_FLINK, &args);
+		err = drmIoctl(bo->drm->fd, DRM_IOCTL_GEM_FLINK, &args);
 		if (err < 0)
 			return -errno;
 
 		pthread_mutex_lock(&table_lock);
 
-		drmHashInsert(drm->name_table, args.name, bo);
+		drmHashInsert(bo->drm->name_table, args.name, bo);
 		bo->name = args.name;
 		bo->reuse = false;
 
@@ -522,14 +515,14 @@ unlock:
 
 int drm_tegra_bo_to_dmabuf(struct drm_tegra_bo *bo, uint32_t *handle)
 {
-	struct drm_tegra *drm = bo->drm;
 	int prime_fd;
 	int err;
 
 	if (!bo || !handle)
 		return -EINVAL;
 
-	err = drmPrimeHandleToFD(drm->fd, bo->handle, DRM_CLOEXEC, &prime_fd);
+	err = drmPrimeHandleToFD(bo->drm->fd, bo->handle, DRM_CLOEXEC,
+				 &prime_fd);
 	if (err)
 		return err;
 

--- a/tegra/tegra.c
+++ b/tegra/tegra.c
@@ -445,6 +445,7 @@ int drm_tegra_bo_from_name(struct drm_tegra_bo **bop, struct drm_tegra *drm,
 	}
 
 	atomic_set(&bo->ref, 1);
+	bo->name = name;
 	bo->handle = args.handle;
 	bo->flags = flags;
 	bo->size = args.size;


### PR DESCRIPTION
Commit 1efbd61 (Thread-safe BO memory mapping) introduced locking for BO's
memory map / unmap, but missed locking around bo->map on unmapping.

Signed-off-by: Dmitry Osipenko <digetx@gmail.com>