### PR TITLE
tegra: Use DRMLISTDELINIT in find_in_bucket

### DIFF
--- a/tegra/tegra_bo_cache.c
+++ b/tegra/tegra_bo_cache.c
@@ -152,7 +152,7 @@ static struct drm_tegra_bo *find_in_bucket(struct drm_tegra_bo_bucket *bucket,
 				  bo_list);
 		/* TODO check for compatible flags? */
 		if (is_idle(bo)) {
-			DRMLISTDEL(&bo->bo_list);
+			DRMLISTDELINIT(&bo->bo_list);
 		} else {
 			bo = NULL;
 		}


### PR DESCRIPTION
In lookup_bo() we are removing BO from cache if it resides in the cache,
however if that BO was re-used from the cache and is in-use during
lookup_bo() invocation, the BO's linked-list next/prev pointers would be
invalid, causing nasty BO cache-list corruption.

Signed-off-by: Dmitry Osipenko <digetx@gmail.com>