### PR TITLE
tegra: guard valgrind macros with HAVE_VALGRIND

### DIFF
--- a/tegra/tegra.c
+++ b/tegra/tegra.c
@@ -289,6 +289,7 @@ int drm_tegra_bo_map(struct drm_tegra_bo *bo, void **ptr)
 		bo->mmap_ref++;
 	}
 
+#ifdef HAVE_VALGRIND
 	if (RUNNING_ON_VALGRIND) {
 		/*
 		 * BO is mapped on creation under valgrind, hence
@@ -304,6 +305,7 @@ int drm_tegra_bo_map(struct drm_tegra_bo *bo, void **ptr)
 		if (bo->mmap_ref == 2)
 			VALGRIND_MAKE_MEM_DEFINED(bo->map, bo->size);
 	}
+#endif
 
 unlock:
 	pthread_mutex_unlock(&table_lock);
@@ -326,12 +328,14 @@ int drm_tegra_bo_unmap(struct drm_tegra_bo *bo)
 	if (!bo->map)
 		goto unlock;
 
+#ifdef HAVE_VALGRIND
 	/*
 	 * mmap_ref is bumped by one under valgrind, hence disable
 	 * access on 2
 	 */
 	if (RUNNING_ON_VALGRIND && bo->mmap_ref == 2)
 		VALGRIND_MAKE_MEM_NOACCESS(bo->map, bo->size);
+#endif
 
 	if (--bo->mmap_ref > 0)
 		goto unlock;


### PR DESCRIPTION
This fixes a compilation-error when valgrind-headers are not
available.

Signed-off-by: Erik Faye-Lund <kusmabite@gmail.com>