### PR TITLE
BO flags cleanup

### DIFF
--- a/tegra/tegra.c
+++ b/tegra/tegra.c
@@ -384,6 +384,10 @@ int drm_tegra_bo_set_flags(struct drm_tegra_bo *bo, uint32_t flags)
 	if (!bo)
 		return -EINVAL;
 
+	/* flags are persistent if BO is reusable */
+	if (bo->reuse && bo->flags == flags)
+		return 0;
+
 	memset(&args, 0, sizeof(args));
 	args.handle = bo->handle;
 	args.flags = flags;
@@ -392,6 +396,8 @@ int drm_tegra_bo_set_flags(struct drm_tegra_bo *bo, uint32_t flags)
 				  sizeof(args));
 	if (err < 0)
 		return err;
+
+	bo->flags = flags;
 
 	return 0;
 }

--- a/tegra/tegra.c
+++ b/tegra/tegra.c
@@ -156,6 +156,9 @@ int drm_tegra_bo_new(struct drm_tegra_bo **bop, struct drm_tegra *drm,
 	if (!drm || size == 0 || !bop)
 		return -EINVAL;
 
+	if (flags & ~DRM_TEGRA_GEM_FLAGS)
+		return -EINVAL;
+
 	bo = drm_tegra_bo_cache_alloc(&drm->bo_cache, &size, flags);
 	if (bo)
 		goto out;
@@ -201,6 +204,9 @@ int drm_tegra_bo_wrap(struct drm_tegra_bo **bop, struct drm_tegra *drm,
 	struct drm_tegra_bo *bo;
 
 	if (!drm || !bop)
+		return -EINVAL;
+
+	if (flags & ~DRM_TEGRA_GEM_FLAGS)
 		return -EINVAL;
 
 	bo = calloc(1, sizeof(*bo));
@@ -382,6 +388,9 @@ int drm_tegra_bo_set_flags(struct drm_tegra_bo *bo, uint32_t flags)
 	int err;
 
 	if (!bo)
+		return -EINVAL;
+
+	if (flags & ~DRM_TEGRA_GEM_FLAGS)
 		return -EINVAL;
 
 	/* flags are persistent if BO is reusable */


### PR DESCRIPTION
Let's fix a possibility of getting a BO with a mismatched flags from cache and maintain flags state after updating them in set_flags().