### PR TITLE
tegra: Refactor and harden valgrind's mmaping a tad

### DIFF
--- a/tegra/private.h
+++ b/tegra/private.h
@@ -93,6 +93,10 @@ struct drm_tegra_bo {
 	void *map;
 
 	bool reuse;
+	/*
+	 * Cache-accessible fields must be at the end of structure
+	 * due to protection of the rest of the fields by valgrind.
+	 */
 	drmMMListHead bo_list;	/* bucket-list entry */
 	time_t free_time;	/* time when added to bucket-list */
 };
@@ -196,8 +200,6 @@ static inline void VG_BO_FREE(struct drm_tegra_bo *bo)
 static inline void VG_BO_RELEASE(struct drm_tegra_bo *bo)
 {
 	if (RUNNING_ON_VALGRIND) {
-		VALGRIND_DISABLE_ADDR_ERROR_REPORTING_IN_RANGE(bo, sizeof(*bo));
-		VALGRIND_MAKE_MEM_NOACCESS(bo, sizeof(*bo));
 		/*
 		 * Disable access in case of an unbalanced BO mmappings to
 		 * simulate the unmap that we perform on BO freeing and
@@ -206,13 +208,19 @@ static inline void VG_BO_RELEASE(struct drm_tegra_bo *bo)
 		 */
 		if (bo->mmap_ref > 1)
 			VALGRIND_FREELIKE_BLOCK(bo->map, 0);
+		/*
+		 * Nothing should touch BO now, disable BO memory accesses
+		 * to catch them in valgrind, but leave cache related stuff
+		 * accessible.
+		 */
+		VALGRIND_MAKE_MEM_NOACCESS(bo, offsetof(typeof(*bo), bo_list));
 	}
 }
 static inline void VG_BO_OBTAIN(struct drm_tegra_bo *bo)
 {
 	if (RUNNING_ON_VALGRIND) {
-		VALGRIND_MAKE_MEM_DEFINED(bo, sizeof(*bo));
-		VALGRIND_ENABLE_ADDR_ERROR_REPORTING_IN_RANGE(bo, sizeof(*bo));
+		/* restore BO memory accesses in valgrind */
+		VALGRIND_MAKE_MEM_DEFINED(bo, offsetof(typeof(*bo), bo_list));
 	}
 }
 
@@ -251,6 +259,7 @@ static inline void VG_BO_RELEASE(struct drm_tegra_bo *bo) {}
 static inline void VG_BO_OBTAIN(struct drm_tegra_bo *bo)  {}
 static inline void VG_BO_MMAP(struct drm_tegra_bo *bo)    {}
 static inline void VG_BO_UNMMAP(struct drm_tegra_bo *bo)  {}
+#define RUNNING_ON_VALGRIND 0
 #endif
 
 #endif /* __DRM_TEGRA_PRIVATE_H__ */

--- a/tegra/tegra.c
+++ b/tegra/tegra.c
@@ -289,24 +289,7 @@ int drm_tegra_bo_map(struct drm_tegra_bo *bo, void **ptr)
 		bo->mmap_ref++;
 	}
 
-#ifdef HAVE_VALGRIND
-	if (RUNNING_ON_VALGRIND) {
-		/*
-		 * BO is mapped on creation under valgrind, hence
-		 * disable access.
-		 */
-		if (bo->mmap_ref == 1)
-			VALGRIND_MAKE_MEM_NOACCESS(bo->map, bo->size);
-
-		/*
-		 * BO is already mapped under valgrind, hence enable
-		 * access.
-		 */
-		if (bo->mmap_ref == 2)
-			VALGRIND_MAKE_MEM_DEFINED(bo->map, bo->size);
-	}
-#endif
-
+	VG_BO_MMAP(bo);
 unlock:
 	pthread_mutex_unlock(&table_lock);
 
@@ -328,14 +311,7 @@ int drm_tegra_bo_unmap(struct drm_tegra_bo *bo)
 	if (!bo->map)
 		goto unlock;
 
-#ifdef HAVE_VALGRIND
-	/*
-	 * mmap_ref is bumped by one under valgrind, hence disable
-	 * access on 2
-	 */
-	if (RUNNING_ON_VALGRIND && bo->mmap_ref == 2)
-		VALGRIND_MAKE_MEM_NOACCESS(bo->map, bo->size);
-#endif
+	VG_BO_UNMMAP(bo);
 
 	if (--bo->mmap_ref > 0)
 		goto unlock;

--- a/tegra/tegra_bo_cache.c
+++ b/tegra/tegra_bo_cache.c
@@ -30,6 +30,7 @@
 
 #include <assert.h>
 #include <pthread.h>
+#include <string.h>
 
 #include "private.h"
 
@@ -164,7 +165,20 @@ static struct drm_tegra_bo *find_in_bucket(struct drm_tegra_bo_bucket *bucket,
 
 static void reset_bo(struct drm_tegra_bo *bo, uint32_t flags)
 {
+	struct drm_tegra_bo_tiling tiling;
+
 	VG_BO_OBTAIN(bo);
+
+	/* XXX: Error handling? */
+	drm_tegra_bo_set_flags(bo, flags);
+
+	/* reset tiling mode */
+	memset(&tiling, 0, sizeof(tiling));
+
+	/* XXX: Error handling? */
+	drm_tegra_bo_set_tiling(bo, &tiling);
+
+	/* reset reference counters */
 	atomic_set(&bo->ref, 1);
 	bo->mmap_ref = RUNNING_ON_VALGRIND ? 1 : 0;
 }

--- a/tegra/tegra_bo_cache.c
+++ b/tegra/tegra_bo_cache.c
@@ -162,6 +162,13 @@ static struct drm_tegra_bo *find_in_bucket(struct drm_tegra_bo_bucket *bucket,
 	return bo;
 }
 
+static void reset_bo(struct drm_tegra_bo *bo, uint32_t flags)
+{
+	VG_BO_OBTAIN(bo);
+	atomic_set(&bo->ref, 1);
+	bo->mmap_ref = RUNNING_ON_VALGRIND ? 1 : 0;
+}
+
 /* NOTE: size is potentially rounded up to bucket size: */
 drm_private struct drm_tegra_bo *
 drm_tegra_bo_cache_alloc(struct drm_tegra_bo_cache *cache,
@@ -178,8 +185,7 @@ drm_tegra_bo_cache_alloc(struct drm_tegra_bo_cache *cache,
 		*size = bucket->size;
 		bo = find_in_bucket(bucket, flags);
 		if (bo) {
-			VG_BO_OBTAIN(bo);
-			atomic_set(&bo->ref, 1);
+			reset_bo(bo, flags);
 			return bo;
 		}
 	}


### PR DESCRIPTION
Let's use macros for BO mmapping / unmapping for consistency with the reset
of valgrind related stuff. Let's disable accessing to mmap region until BO
has been actually mmap'ed using drm_tegra_bo_map.

Signed-off-by: Dmitry Osipenko <digetx@gmail.com>