### PR TITLE
Revert "tegra: Switch to use of drmMap / drmUnmap"

### DIFF
--- a/tegra/tegra.c
+++ b/tegra/tegra.c
@@ -300,9 +300,13 @@ int drm_tegra_bo_map(struct drm_tegra_bo *bo, void **ptr)
 		if (err < 0)
 			goto unlock;
 
-		err = drmMap(bo->drm->fd, args.offset, bo->size, &bo->map);
-		if (err < 0)
+		bo->map = mmap(0, bo->size, PROT_READ | PROT_WRITE, MAP_SHARED,
+			       bo->drm->fd, args.offset);
+		if (bo->map == MAP_FAILED) {
+			bo->map = NULL;
+			err = -errno;
 			goto unlock;
+		}
 
 		bo->mmap_ref = 1;
 	} else {
@@ -336,7 +340,7 @@ int drm_tegra_bo_unmap(struct drm_tegra_bo *bo)
 	if (--bo->mmap_ref > 0)
 		goto unlock;
 
-	err = drmUnmap(bo->map, bo->size);
+	err = munmap(bo->map, bo->size);
 	if (err < 0) {
 		err = -errno;
 		goto unlock;


### PR DESCRIPTION
Mikko Perttunen tried to run Opentegra on TX1 that is 64bit arch and it
failed on drm_tegra_bo_map(), Thierry Reding pointed that drmOpen() isn't
well suited for the 64bit because drm_handle_t (mmap offset) is 32bit,
let's return back to bare mmap() to fix the issue.

This reverts commit cc2c7e4ae101458201a88ab709215746b72f21b3.

Signed-off-by: Dmitry Osipenko <digetx@gmail.com>