### PR TITLE
tegra: Fix lockups under valgrind

### DIFF
--- a/tegra/private.h
+++ b/tegra/private.h
@@ -155,6 +155,7 @@ int drm_tegra_job_add_cmdbuf(struct drm_tegra_job *job,
 			     const struct drm_tegra_cmdbuf *cmdbuf);
 
 int drm_tegra_bo_free(struct drm_tegra_bo *bo);
+int drm_tegra_bo_map_locked(struct drm_tegra_bo *bo, void **ptr);
 
 void drm_tegra_bo_cache_init(struct drm_tegra_bo_cache *cache, bool coarse);
 void drm_tegra_bo_cache_cleanup(struct drm_tegra_bo_cache *cache, time_t time);
@@ -176,7 +177,7 @@ static inline void VG_BO_ALLOC(struct drm_tegra_bo *bo)
 	void *map;
 
 	if (bo && RUNNING_ON_VALGRIND) {
-		drm_tegra_bo_map(bo, &map);
+		drm_tegra_bo_map_locked(bo, &map);
 		VALGRIND_FREELIKE_BLOCK(map, 0);
 	}
 }

--- a/tegra/tegra.c
+++ b/tegra/tegra.c
@@ -280,14 +280,9 @@ int drm_tegra_bo_get_handle(struct drm_tegra_bo *bo, uint32_t *handle)
 	return 0;
 }
 
-int drm_tegra_bo_map(struct drm_tegra_bo *bo, void **ptr)
+drm_private int drm_tegra_bo_map_locked(struct drm_tegra_bo *bo, void **ptr)
 {
 	int err = 0;
-
-	if (!bo)
-		return -EINVAL;
-
-	pthread_mutex_lock(&table_lock);
 
 	if (!bo->map) {
 		struct drm_tegra_gem_mmap args;
@@ -298,14 +293,14 @@ int drm_tegra_bo_map(struct drm_tegra_bo *bo, void **ptr)
 		err = drmCommandWriteRead(bo->drm->fd, DRM_TEGRA_GEM_MMAP,
 					  &args, sizeof(args));
 		if (err < 0)
-			goto unlock;
+			goto out;
 
 		bo->map = mmap(0, bo->size, PROT_READ | PROT_WRITE, MAP_SHARED,
 			       bo->drm->fd, args.offset);
 		if (bo->map == MAP_FAILED) {
 			bo->map = NULL;
 			err = -errno;
-			goto unlock;
+			goto out;
 		}
 
 		bo->mmap_ref = 1;
@@ -314,11 +309,25 @@ int drm_tegra_bo_map(struct drm_tegra_bo *bo, void **ptr)
 	}
 
 	VG_BO_MMAP(bo);
-unlock:
-	pthread_mutex_unlock(&table_lock);
-
+out:
 	if (ptr)
 		*ptr = bo->map;
+
+	return err;
+}
+
+int drm_tegra_bo_map(struct drm_tegra_bo *bo, void **ptr)
+{
+	int err;
+
+	if (!bo)
+		return -EINVAL;
+
+	pthread_mutex_lock(&table_lock);
+
+	err = drm_tegra_bo_map_locked(bo, ptr);
+
+	pthread_mutex_unlock(&table_lock);
 
 	return err;
 }


### PR DESCRIPTION
VG_BO_ALLOC() should be outside of table lock because it invokes
drm_tegra_bo_map() that takes the same lock.

Signed-off-by: Dmitry Osipenko <digetx@gmail.com>