### PR TITLE
tegra: Correct typo in drm_tegra_job_add_reloc

### DIFF
--- a/tegra/job.c
+++ b/tegra/job.c
@@ -44,7 +44,7 @@ int drm_tegra_job_add_reloc(struct drm_tegra_job *job,
 	size = (job->num_relocs + 1) * sizeof(*reloc);
 
 	relocs = realloc(job->relocs, size);
-	if (!reloc)
+	if (!relocs)
 		return -ENOMEM;
 
 	job->relocs = relocs;


### PR DESCRIPTION
This would avoid crashing/corruption in a case of reallocation failure.

Signed-off-by: Dmitry Osipenko <digetx@gmail.com>