### PR TITLE
tegra: Cache BO mappings

### DIFF
--- a/tegra/private.h
+++ b/tegra/private.h
@@ -64,6 +64,11 @@ struct drm_tegra_bo_cache {
 	time_t time;
 };
 
+struct drm_tegra_bo_mmap_cache {
+	drmMMListHead list;
+	time_t time;
+};
+
 struct drm_tegra {
 	/* tables to keep track of bo's, to avoid "evil-twin" buffer objects:
 	 *
@@ -77,6 +82,7 @@ struct drm_tegra {
 	void *handle_table, *name_table;
 
 	struct drm_tegra_bo_cache bo_cache;
+	struct drm_tegra_bo_mmap_cache mmap_cache;
 	bool close;
 	int fd;
 };
@@ -99,6 +105,11 @@ struct drm_tegra_bo {
 	 */
 	drmMMListHead bo_list;	/* bucket-list entry */
 	time_t free_time;	/* time when added to bucket-list */
+
+	drmMMListHead mmap_list;	/* mmap cache-list entry */
+	time_t unmap_time;		/* time when added to cache-list */
+	void *map_cached;		/* holds cached mmap pointer */
+
 };
 
 struct drm_tegra_channel {
@@ -164,6 +175,8 @@ struct drm_tegra_bo * drm_tegra_bo_cache_alloc(
 		uint32_t *size, uint32_t flags);
 int drm_tegra_bo_cache_free(struct drm_tegra_bo_cache *cache,
 			    struct drm_tegra_bo *bo);
+void drm_tegra_bo_cache_unmap(struct drm_tegra_bo *bo);
+void *drm_tegra_bo_cache_map(struct drm_tegra_bo *bo);
 
 #ifdef HAVE_VALGRIND
 #  include <memcheck.h>

--- a/tegra/tegra.c
+++ b/tegra/tegra.c
@@ -68,6 +68,11 @@ drm_private int drm_tegra_bo_free(struct drm_tegra_bo *bo)
 	if (bo->map)
 		munmap(bo->map, bo->size);
 
+	if (bo->map_cached) {
+		munmap(bo->map_cached, bo->size);
+		DRMLISTDEL(&bo->mmap_list);
+	}
+
 	if (bo->name)
 		drmHashDelete(drm->name_table, bo->name);
 
@@ -102,6 +107,7 @@ static int drm_tegra_wrap(struct drm_tegra **drmp, int fd, bool close)
 	drm_tegra_bo_cache_init(&drm->bo_cache, false);
 	drm->handle_table = drmHashCreate();
 	drm->name_table = drmHashCreate();
+	DRMINITLISTHEAD(&drm->mmap_cache.list);
 
 	if (!drm->handle_table || !drm->name_table)
 		return -ENOMEM;
@@ -287,6 +293,10 @@ drm_private int drm_tegra_bo_map_locked(struct drm_tegra_bo *bo, void **ptr)
 	if (!bo->map) {
 		struct drm_tegra_gem_mmap args;
 
+		bo->map = drm_tegra_bo_cache_map(bo);
+		if (bo->map)
+			goto ref_mmap;
+
 		memset(&args, 0, sizeof(args));
 		args.handle = bo->handle;
 
@@ -302,7 +312,7 @@ drm_private int drm_tegra_bo_map_locked(struct drm_tegra_bo *bo, void **ptr)
 			err = -errno;
 			goto out;
 		}
-
+ref_mmap:
 		bo->mmap_ref = 1;
 	} else {
 		bo->mmap_ref++;
@@ -334,8 +344,6 @@ int drm_tegra_bo_map(struct drm_tegra_bo *bo, void **ptr)
 
 int drm_tegra_bo_unmap(struct drm_tegra_bo *bo)
 {
-	int err = 0;
-
 	if (!bo)
 		return -EINVAL;
 
@@ -349,18 +357,12 @@ int drm_tegra_bo_unmap(struct drm_tegra_bo *bo)
 	if (--bo->mmap_ref > 0)
 		goto unlock;
 
-	err = munmap(bo->map, bo->size);
-	if (err < 0) {
-		err = -errno;
-		goto unlock;
-	}
-
+	drm_tegra_bo_cache_unmap(bo);
 	bo->map = NULL;
-
 unlock:
 	pthread_mutex_unlock(&table_lock);
 
-	return err;
+	return 0;
 }
 
 int drm_tegra_bo_get_flags(struct drm_tegra_bo *bo, uint32_t *flags)


### PR DESCRIPTION
Implement deferred BO unmapping in a way deferred BO freeing is done for BO's caching.

This improves overall performance quite significantly.