### PR TITLE
tegra: Re-acquire BO mapping in valgrind

### DIFF
--- a/tegra/private.h
+++ b/tegra/private.h
@@ -235,6 +235,9 @@ static inline void VG_BO_OBTAIN(struct drm_tegra_bo *bo)
 	if (RUNNING_ON_VALGRIND) {
 		/* restore BO memory accesses in valgrind */
 		VALGRIND_MAKE_MEM_DEFINED(bo, offsetof(typeof(*bo), bo_list));
+
+		if (bo->mmap_ref > 1)
+			VALGRIND_MALLOCLIKE_BLOCK(bo->map, bo->size, 0, 1);
 	}
 }
 


### PR DESCRIPTION
The taken from cache BO may retain mapping, so we need to restore access to the mapping to fix valgrind's complaining.

	==2796== Block 0x4027000..0x402afff overlaps with block 0x4027000..0x402afff
	==2796== Blocks allocation contexts:
	==2796==    at 0x558290C: VG_BO_OBTAIN (private.h:226)
	==2796==    by 0x558290C: is_idle (tegra_bo_cache.c:136)
	==2796==    by 0x558290C: find_in_bucket (tegra_bo_cache.c:163)
	==2796==    by 0x558290C: drm_tegra_bo_cache_alloc (tegra_bo_cache.c:206)
	==2796==    by 0x5581767: drm_tegra_bo_new (tegra.c:165)
	==2796==    by 0x556551B: dumb_bo_create (drmmode_display.c:44)
	==2796==    by 0x5566523: drmmode_create_initial_bos (drmmode_display.c:1621)
	==2796==    by 0x5561FBB: TegraScreenInit (driver.c:827)
	==2796==    by 0x15155B: AddScreen (dispatch.c:3910)
	==2796==    by 0x191723: InitOutput (xf86Init.c:787)
	==2796==    by 0x1552D7: dix_main (main.c:193)
	==2796==    by 0x4C1713B: (below main) (libc-start.c:295)
	==2796==
	==2796==    at 0x5581488: VG_BO_MMAP (private.h:244)
	==2796==    by 0x5581488: drm_tegra_bo_map_locked (tegra.c:321)
	==2796==    by 0x5581943: drm_tegra_bo_map (tegra.c:338)
	==2796==    by 0x55665EB: dumb_bo_map (drmmode_display.c:62)
	==2796==    by 0x55665EB: drmmode_map_cursor_bos (drmmode_display.c:1671)
	==2796==    by 0x5561723: TegraCreateScreenResources (driver.c:717)
	==2796==    by 0x55BD12B: exaCreateScreenResources (exa.c:667)
	==2796==    by 0x1C069F: xf86CrtcCreateScreenResources (xf86Crtc.c:714)
	==2796==    by 0x15537B: dix_main (main.c:214)
	==2796==    by 0x4C1713B: (below main) (libc-start.c:295)
	==2796== This is usually caused by using VALGRIND_MALLOCLIKE_BLOCK in an inappropriate way.