### PR TITLE
drm/tegra: Don't forbid caching of potentially exported BO's

### DIFF
--- a/tegra/tegra.c
+++ b/tegra/tegra.c
@@ -469,7 +469,6 @@ int drm_tegra_bo_get_name(struct drm_tegra_bo *bo, uint32_t *name)
 
 		drmHashInsert(bo->drm->name_table, args.name, bo);
 		bo->name = args.name;
-		bo->reuse = false;
 
 		pthread_mutex_unlock(&table_lock);
 	}
@@ -552,8 +551,6 @@ int drm_tegra_bo_to_dmabuf(struct drm_tegra_bo *bo, uint32_t *handle)
 				 &prime_fd);
 	if (err)
 		return err;
-
-	bo->reuse = false;
 
 	*handle = prime_fd;
 


### PR DESCRIPTION
Forbidding caching of BO's after getting dmabuf FD or flink name isn't
a good strategy and prevents libvdpau-tegra from caching. We have a handle
for explicitly forbidding caching of a particular BO, let's don't mess with
the BO's caching in libdrm and instead let the user to decide what BO's
shouldn't be cached.