### PR TITLE
tegra: Unmap cached BO on reset under valgrind

### DIFF
--- a/tegra/private.h
+++ b/tegra/private.h
@@ -260,9 +260,9 @@ static inline void VG_BO_UNMMAP(struct drm_tegra_bo *bo)
 	if (RUNNING_ON_VALGRIND) {
 		/*
 		 * BO's mmap_ref is bumped by one under valgrind, hence
-		 * disable access on 2.
+		 * disable access on 1.
 		 */
-		if (bo->mmap_ref == 2)
+		if (bo->mmap_ref < 2)
 			VALGRIND_FREELIKE_BLOCK(bo->map, 0);
 	}
 }

--- a/tegra/tegra.c
+++ b/tegra/tegra.c
@@ -352,9 +352,10 @@ int drm_tegra_bo_unmap(struct drm_tegra_bo *bo)
 	if (!bo->map)
 		goto unlock;
 
+	bo->mmap_ref--;
 	VG_BO_UNMMAP(bo);
 
-	if (--bo->mmap_ref > 0)
+	if (bo->mmap_ref > 0)
 		goto unlock;
 
 	drm_tegra_bo_cache_unmap(bo);

--- a/tegra/tegra_bo_cache.c
+++ b/tegra/tegra_bo_cache.c
@@ -166,6 +166,7 @@ static struct drm_tegra_bo *find_in_bucket(struct drm_tegra_bo_bucket *bucket,
 static void reset_bo(struct drm_tegra_bo *bo, uint32_t flags)
 {
 	struct drm_tegra_bo_tiling tiling;
+	bool mapped;
 
 	VG_BO_OBTAIN(bo);
 
@@ -178,9 +179,15 @@ static void reset_bo(struct drm_tegra_bo *bo, uint32_t flags)
 	/* XXX: Error handling? */
 	drm_tegra_bo_set_tiling(bo, &tiling);
 
+	mapped = (RUNNING_ON_VALGRIND && bo->mmap_ref > 1);
+
 	/* reset reference counters */
 	atomic_set(&bo->ref, 1);
 	bo->mmap_ref = RUNNING_ON_VALGRIND ? 1 : 0;
+
+	/* mark BO as unmapped */
+	if (mapped)
+		VG_BO_UNMMAP(bo);
 }
 
 /* NOTE: size is potentially rounded up to bucket size: */


### PR DESCRIPTION
The taken out from cache BO may retain memory mapping and since the mmap
refcount is reset, BO mapping should be marked as unmapped under valgrind
to avoid complaining about double mmaping on further BO memory mapping.

==755== Block 0x152ca000..0x153c9fff overlaps with block 0x152ca000..0x153c9fff
==755== Blocks allocation contexts:
==755==    at 0x14AA103C: VG_BO_OBTAIN (private.h:230)
==755==    by 0x14AA103C: reset_bo (tegra_bo_cache.c:180)
==755==    by 0x14AA103C: drm_tegra_bo_cache_alloc (tegra_bo_cache.c:213)
==755==    by 0x14A9FB07: drm_tegra_bo_new (tegra.c:166)
==755==    by 0x48733EB: host1x_pixelbuffer_create (host1x-pixelbuffer.c:102)
==755==    by 0x486E73F: alloc_surface_data (surface.c:136)
==755==    by 0x486EDEF: alloc_surface (surface.c:384)
==755==    by 0x486E233: shared_surface_swap_video (surface_shared.c:157)
==755==    by 0x48711CB: vdp_decoder_render (decoder.c:605)
==755==    by 0x4F7ACCB: ff_vdpau_common_end_frame (vdpau.c:372)
==755==    by 0x4F7BCA3: vdpau_h264_end_frame (vdpau_h264.c:210)
==755==    by 0x4CD65BF: ff_h264_field_end (h264_picture.c:172)
==755==    by 0x4CE8933: h264_decode_frame (h264dec.c:1025)
==755==    by 0x4C18DA7: decode_simple_internal (decode.c:417)
==755==    by 0x4C18DA7: decode_simple_receive_frame (decode.c:620)
==755==    by 0x4C18DA7: decode_receive_frame_internal (decode.c:638)
==755==
==755==    at 0x14AA103C: VG_BO_OBTAIN (private.h:230)
==755==    by 0x14AA103C: reset_bo (tegra_bo_cache.c:180)
==755==    by 0x14AA103C: drm_tegra_bo_cache_alloc (tegra_bo_cache.c:213)
==755==    by 0x14A9FB07: drm_tegra_bo_new (tegra.c:166)
==755==    by 0x48733EB: host1x_pixelbuffer_create (host1x-pixelbuffer.c:102)
==755==    by 0x486E73F: alloc_surface_data (surface.c:136)
==755==    by 0x486EDEF: alloc_surface (surface.c:384)
==755==    by 0x486E233: shared_surface_swap_video (surface_shared.c:157)
==755==    by 0x48711CB: vdp_decoder_render (decoder.c:605)
==755==    by 0x4F7ACCB: ff_vdpau_common_end_frame (vdpau.c:372)
==755==    by 0x4F7BCA3: vdpau_h264_end_frame (vdpau_h264.c:210)
==755==    by 0x4CD65BF: ff_h264_field_end (h264_picture.c:172)
==755==    by 0x4CE8933: h264_decode_frame (h264dec.c:1025)
==755==    by 0x4C18DA7: decode_simple_internal (decode.c:417)
==755==    by 0x4C18DA7: decode_simple_receive_frame (decode.c:620)
==755==    by 0x4C18DA7: decode_receive_frame_internal (decode.c:638)

Signed-off-by: Dmitry Osipenko <digetx@gmail.com>