### PR TITLE
tegra: correct symbols checking

### DIFF
--- a/tegra/tegra-symbol-check
+++ b/tegra/tegra-symbol-check
@@ -36,7 +36,7 @@ drm_tegra_pushbuf_free
 drm_tegra_pushbuf_prepare
 drm_tegra_pushbuf_relocate
 drm_tegra_pushbuf_sync
-drm_tegra_fence_wait_timeou
+drm_tegra_fence_wait_timeout
 drm_tegra_fence_free
 drm_tegra_bo_get_name
 drm_tegra_bo_from_name
@@ -44,6 +44,7 @@ drm_tegra_bo_from_dmabuf
 drm_tegra_bo_to_dmabuf
 drm_tegra_bo_get_size
 drm_tegra_bo_forbid_caching
+drm_tegra_bo_cpu_prep
 EOF
 done)
 


### PR DESCRIPTION
Fix a typo and add missed function to tegra-symbol-check, this fixes 'make check'.