### PR TITLE
tegra: Really correct symbols checking

### DIFF
--- a/tegra/tegra-symbol-check
+++ b/tegra/tegra-symbol-check
@@ -44,7 +44,6 @@ drm_tegra_bo_from_dmabuf
 drm_tegra_bo_to_dmabuf
 drm_tegra_bo_get_size
 drm_tegra_bo_forbid_caching
-drm_tegra_bo_cpu_prep
 EOF
 done)
 


### PR DESCRIPTION
Remove drm_tegra_bo_forbid_caching that was added by accident in commit 4784227adba8 ("correct symbols checking").