### PR TITLE
Debug

### DIFF
--- a/tegra/private.h
+++ b/tegra/private.h
@@ -127,6 +127,8 @@ struct drm_tegra {
 	int fd;
 
 	bool debug_bo;
+	bool debug_bo_back_guard;
+	bool debug_bo_front_guard;
 	int32_t debug_bos_allocated;
 	int32_t debug_bos_total_size;
 	int32_t debug_bos_cached;
@@ -168,6 +170,9 @@ struct drm_tegra_bo {
 	bool custom_flags;
 
 	uint32_t debug_size;
+
+	uint64_t *guard_front;
+	uint64_t *guard_back;
 };
 
 struct drm_tegra_channel {

--- a/tegra/private.h
+++ b/tegra/private.h
@@ -47,6 +47,7 @@
 
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 
+#ifndef NDEBUG
 #define VDBG_DRM(DRM, FMT, ...) do {					\
 	if (DRM->debug_bo)						\
 		fprintf(stderr, "%s: %d: " FMT,				\
@@ -85,6 +86,12 @@
 } while (0)
 
 #define DBG_BO(BO, FMT) VDBG_BO(BO, FMT "%s", "")
+#else
+#define VDBG_DRM(DRM, FMT, ...)	do {} while (0)
+#define DBG_BO_STATS(DRM)	do {} while (0)
+#define VDBG_BO(BO, FMT, ...)	do {} while (0)
+#define DBG_BO(BO, FMT)		do {} while (0)
+#endif
 
 enum host1x_class {
 	HOST1X_CLASS_HOST1X = 0x01,
@@ -126,6 +133,7 @@ struct drm_tegra {
 	bool close;
 	int fd;
 
+#ifndef NDEBUG
 	bool debug_bo;
 	bool debug_bo_back_guard;
 	bool debug_bo_front_guard;
@@ -136,6 +144,7 @@ struct drm_tegra {
 	int32_t debug_bos_total_pages;
 	int32_t debug_bos_cached_pages;
 	int32_t debug_bos_mappings_cached;
+#endif
 };
 
 struct drm_tegra_bo {
@@ -169,10 +178,12 @@ struct drm_tegra_bo {
 	bool custom_tiling;
 	bool custom_flags;
 
+#ifndef NDEBUG
 	uint32_t debug_size;
 
 	uint64_t *guard_front;
 	uint64_t *guard_back;
+#endif
 };
 
 struct drm_tegra_channel {

--- a/tegra/tegra.c
+++ b/tegra/tegra.c
@@ -63,19 +63,39 @@ drm_private int drm_tegra_bo_free(struct drm_tegra_bo *bo)
 	struct drm_gem_close args;
 	int err;
 
+	DBG_BO(bo, "\n");
+
+	if (drm->debug_bo) {
+		drm->debug_bos_allocated--;
+		drm->debug_bos_total_size -= bo->debug_size;
+	}
+
 	if (bo->map) {
 		if (RUNNING_ON_VALGRIND)
 			VG_BO_UNMMAP(bo);
 		else
-			munmap(bo->map, bo->size);
+			munmap(bo->map, bo->offset + bo->size);
 
 	} else if (bo->map_cached) {
 		if (!RUNNING_ON_VALGRIND)
-			munmap(bo->map_cached, bo->size);
+			munmap(bo->map_cached, bo->offset + bo->size);
 
 		DRMLISTDEL(&bo->mmap_list);
+
+		if (drm->debug_bo) {
+			drm->debug_bos_mappings_cached--;
+			drm->debug_bos_cached_pages -= bo->debug_size / 4096;
+		}
+	} else {
+		goto vg_free;
 	}
 
+	if (drm->debug_bo) {
+		drm->debug_bos_mapped--;
+		drm->debug_bos_total_pages -= bo->debug_size / 4096;
+	}
+
+vg_free:
 	VG_BO_FREE(bo);
 
 	if (bo->name)
@@ -92,12 +112,15 @@ drm_private int drm_tegra_bo_free(struct drm_tegra_bo *bo)
 
 	free(bo);
 
+	DBG_BO_STATS(drm);
+
 	return err;
 }
 
 static int drm_tegra_wrap(struct drm_tegra **drmp, int fd, bool close)
 {
 	struct drm_tegra *drm;
+	char *str;
 
 	if (fd < 0 || !drmp)
 		return -EINVAL;
@@ -116,6 +139,9 @@ static int drm_tegra_wrap(struct drm_tegra **drmp, int fd, bool close)
 
 	if (!drm->handle_table || !drm->name_table)
 		return -ENOMEM;
+
+	str = getenv("LIBDRM_TEGRA_DEBUG_BO");
+	drm->debug_bo = (str && strcmp(str, "1") == 0);
 
 	*drmp = drm;
 
@@ -147,7 +173,7 @@ void drm_tegra_close(struct drm_tegra *drm)
 	if (!drm)
 		return;
 
-	drm_tegra_bo_cache_cleanup(&drm->bo_cache, 0);
+	drm_tegra_bo_cache_cleanup(drm, 0);
 	drmHashDestroy(drm->handle_table);
 	drmHashDestroy(drm->name_table);
 
@@ -167,9 +193,11 @@ int drm_tegra_bo_new(struct drm_tegra_bo **bop, struct drm_tegra *drm,
 	if (!drm || size == 0 || !bop)
 		return -EINVAL;
 
-	bo = drm_tegra_bo_cache_alloc(&drm->bo_cache, &size, flags);
-	if (bo)
+	bo = drm_tegra_bo_cache_alloc(drm, &size, flags);
+	if (bo) {
+		DBG_BO(bo, "success from cache\n");
 		goto out;
+	}
 
 	bo = calloc(1, sizeof(*bo));
 	if (!bo)
@@ -190,19 +218,28 @@ int drm_tegra_bo_new(struct drm_tegra_bo **bop, struct drm_tegra *drm,
 	err = drmCommandWriteRead(drm->fd, DRM_TEGRA_GEM_CREATE, &args,
 				  sizeof(args));
 	if (err < 0) {
+		VDBG_DRM(drm, "failed size %u bytes flags 0x%08X err %d (%s)\n",
+			 size, flags, err, strerror(-err));
 		free(bo);
 		return err;
 	}
 
 	bo->handle = args.handle;
 
+	DBG_BO(bo, "success new\n");
 	VG_BO_ALLOC(bo);
 
-	pthread_mutex_lock(&table_lock);
+	if (drm->debug_bo) {
+		bo->debug_size = align(bo->size, 4096);
+		drm->debug_bos_total_size += bo->debug_size;
+		drm->debug_bos_allocated++;
+	}
 
+	DBG_BO_STATS(drm);
+
+	pthread_mutex_lock(&table_lock);
 	/* add ourselves into the handle table */
 	drmHashInsert(drm->handle_table, args.handle, bo);
-
 	pthread_mutex_unlock(&table_lock);
 out:
 	*bop = bo;
@@ -245,6 +282,7 @@ int drm_tegra_bo_wrap(struct drm_tegra_bo **bop, struct drm_tegra *drm,
 	/* add ourselves into the handle table */
 	drmHashInsert(drm->handle_table, handle, bo);
 
+	DBG_BO(bo, "success\n");
 unlock:
 	pthread_mutex_unlock(&table_lock);
 
@@ -255,8 +293,11 @@ unlock:
 
 struct drm_tegra_bo *drm_tegra_bo_ref(struct drm_tegra_bo *bo)
 {
-	if (bo)
+	if (bo) {
+		DBG_BO(bo, "\n");
+
 		atomic_inc(&bo->ref);
+	}
 
 	return bo;
 }
@@ -268,12 +309,14 @@ int drm_tegra_bo_unref(struct drm_tegra_bo *bo)
 	if (!bo)
 		return -EINVAL;
 
+	DBG_BO(bo, "\n");
+
 	if (!atomic_dec_and_test(&bo->ref))
 		return 0;
 
 	pthread_mutex_lock(&table_lock);
 
-	if (!bo->reuse || drm_tegra_bo_cache_free(&bo->drm->bo_cache, bo))
+	if (!bo->reuse || drm_tegra_bo_cache_free(bo))
 		err = drm_tegra_bo_free(bo);
 
 	pthread_mutex_unlock(&table_lock);
@@ -293,13 +336,16 @@ int drm_tegra_bo_get_handle(struct drm_tegra_bo *bo, uint32_t *handle)
 
 drm_private int __drm_tegra_bo_map(struct drm_tegra_bo *bo, void **ptr)
 {
+	struct drm_tegra *drm = bo->drm;
 	struct drm_tegra_gem_mmap args;
-	void *map;
+	uint8_t *map;
 	int err;
 
 	map = drm_tegra_bo_cache_map(bo);
-	if (map)
+	if (map) {
+		DBG_BO(bo, "success from cache\n");
 		goto out;
+	}
 
 #ifdef HAVE_VALGRIND
 	if (RUNNING_ON_VALGRIND && bo->map_vg) {
@@ -311,19 +357,34 @@ drm_private int __drm_tegra_bo_map(struct drm_tegra_bo *bo, void **ptr)
 	memset(&args, 0, sizeof(args));
 	args.handle = bo->handle;
 
-	err = drmCommandWriteRead(bo->drm->fd, DRM_TEGRA_GEM_MMAP,
-					&args, sizeof(args));
-	if (err < 0)
+	err = drmCommandWriteRead(drm->fd, DRM_TEGRA_GEM_MMAP,
+				  &args, sizeof(args));
+	if (err < 0) {
+		VDBG_BO(bo, "failed get mapping offset err %d (%s)\n",
+			err, strerror(-err));
 		return err;
+	}
 
-	map = mmap(0, bo->size, PROT_READ | PROT_WRITE, MAP_SHARED,
-			bo->drm->fd, args.offset);
+	map = mmap(0, bo->offset + bo->size, PROT_READ | PROT_WRITE, MAP_SHARED,
+		   drm->fd, args.offset);
 	if (map == MAP_FAILED) {
+		VDBG_BO(bo, "failed to map offset 0x%llX err %d (%s)\n",
+			args.offset, -errno, strerror(errno));
 		*ptr = NULL;
 		return -errno;
 	}
+
+	map += bo->offset;
 out:
 	*ptr = map;
+
+	if (drm->debug_bo && ptr == &bo->map) {
+		drm->debug_bos_mapped++;
+		drm->debug_bos_total_pages += bo->debug_size / 4096;
+	}
+
+	DBG_BO(bo, "success\n");
+	DBG_BO_STATS(drm);
 
 	return 0;
 }
@@ -346,6 +407,7 @@ int drm_tegra_bo_map(struct drm_tegra_bo *bo, void **ptr)
 
 		bo->mmap_ref = 1;
 	} else {
+		DBG_BO(bo, "\n");
 		bo->mmap_ref++;
 	}
 out:
@@ -361,6 +423,8 @@ int drm_tegra_bo_unmap(struct drm_tegra_bo *bo)
 {
 	if (!bo)
 		return -EINVAL;
+
+	DBG_BO(bo, "\n");
 
 	pthread_mutex_lock(&table_lock);
 
@@ -393,11 +457,16 @@ int drm_tegra_bo_get_flags(struct drm_tegra_bo *bo, uint32_t *flags)
 
 	err = drmCommandWriteRead(bo->drm->fd, DRM_TEGRA_GEM_GET_FLAGS, &args,
 				  sizeof(args));
-	if (err < 0)
+	if (err < 0) {
+		VDBG_BO(bo, "failed err %d strerror(%s)\n",
+			err, strerror(-err));
 		return err;
+	}
 
 	if (flags)
 		*flags = args.flags;
+
+	VDBG_BO(bo, "success flags 0x%08X\n", args.flags);
 
 	return 0;
 }
@@ -416,10 +485,13 @@ int drm_tegra_bo_set_flags(struct drm_tegra_bo *bo, uint32_t flags)
 
 	err = drmCommandWriteRead(bo->drm->fd, DRM_TEGRA_GEM_SET_FLAGS, &args,
 				  sizeof(args));
-	if (err < 0)
+	if (err < 0) {
+		VDBG_BO(bo, "failed err %d strerror(%s)\n",
+			err, strerror(-err));
 		return err;
+	}
 
-	bo->custom_flags = (flags != 0);
+	DBG_BO(bo, "success\n");
 
 	return 0;
 }
@@ -438,13 +510,18 @@ int drm_tegra_bo_get_tiling(struct drm_tegra_bo *bo,
 
 	err = drmCommandWriteRead(bo->drm->fd, DRM_TEGRA_GEM_GET_TILING, &args,
 				  sizeof(args));
-	if (err < 0)
+	if (err < 0) {
+		VDBG_BO(bo, "failed err %d strerror(%s)\n",
+			err, strerror(-err));
 		return err;
+	}
 
 	if (tiling) {
 		tiling->mode = args.mode;
 		tiling->value = args.value;
 	}
+
+	VDBG_BO(bo, "success mode %u value %u\n", args.mode, args.value);
 
 	return 0;
 }
@@ -465,8 +542,13 @@ int drm_tegra_bo_set_tiling(struct drm_tegra_bo *bo,
 
 	err = drmCommandWriteRead(bo->drm->fd, DRM_TEGRA_GEM_SET_TILING,
 				  &args, sizeof(args));
-	if (err < 0)
+	if (err < 0) {
+		VDBG_BO(bo, "failed mode %u value %u err %d strerror(%s)\n",
+			tiling->mode, tiling->value, err, strerror(-err));
 		return err;
+	}
+
+	VDBG_BO(bo, "success mode %u value %u\n", tiling->mode, tiling->value);
 
 	bo->custom_tiling = (tiling->mode || tiling->value);
 
@@ -486,8 +568,11 @@ int drm_tegra_bo_get_name(struct drm_tegra_bo *bo, uint32_t *name)
 		args.handle = bo->handle;
 
 		err = drmIoctl(bo->drm->fd, DRM_IOCTL_GEM_FLINK, &args);
-		if (err < 0)
+		if (err < 0) {
+			VDBG_BO(bo, "err %d strerror(%s)\n",
+				err, strerror(-err));
 			return -errno;
+		}
 
 		pthread_mutex_lock(&table_lock);
 
@@ -498,6 +583,8 @@ int drm_tegra_bo_get_name(struct drm_tegra_bo *bo, uint32_t *name)
 	}
 
 	*name = bo->name;
+
+	DBG_BO(bo, "\n");
 
 	return 0;
 }
@@ -531,6 +618,8 @@ int drm_tegra_bo_from_name(struct drm_tegra_bo **bop, struct drm_tegra *drm,
 
 	err = drmIoctl(drm->fd, DRM_IOCTL_GEM_OPEN, &args);
 	if (err < 0) {
+		VDBG_DRM(drm, "failed name 0x%08X err %d strerror(%s)\n",
+			 name, err, strerror(-err));
 		err = -errno;
 		free(bo);
 		bo = NULL;
@@ -540,6 +629,7 @@ int drm_tegra_bo_from_name(struct drm_tegra_bo **bop, struct drm_tegra *drm,
 	/* check handle table second, to see if BO is already open */
 	dup = lookup_bo(drm->handle_table, args.handle);
 	if (dup) {
+		VDBG_BO(dup, "success reused name 0x%08X\n", name);
 		free(bo);
 		bo = dup;
 		goto unlock;
@@ -552,6 +642,8 @@ int drm_tegra_bo_from_name(struct drm_tegra_bo **bop, struct drm_tegra *drm,
 	bo->flags = flags;
 	bo->size = args.size;
 	bo->drm = drm;
+
+	DBG_BO(bo, "success\n");
 
 	VG_BO_ALLOC(bo);
 
@@ -573,10 +665,15 @@ int drm_tegra_bo_to_dmabuf(struct drm_tegra_bo *bo, uint32_t *handle)
 
 	err = drmPrimeHandleToFD(bo->drm->fd, bo->handle, DRM_CLOEXEC,
 				 &prime_fd);
-	if (err)
+	if (err) {
+		VDBG_BO(bo, "faile err %d strerror(%s)\n",
+			err, strerror(-err));
 		return err;
+	}
 
 	*handle = prime_fd;
+
+	VDBG_BO(bo, "success prime_fd %u\n",  prime_fd);
 
 	return 0;
 }
@@ -611,6 +708,7 @@ int drm_tegra_bo_from_dmabuf(struct drm_tegra_bo **bop, struct drm_tegra *drm,
 	/* check handle table to see if BO is already open */
 	dup = lookup_bo(drm->handle_table, handle);
 	if (dup) {
+		DBG_BO(dup, "success reused\n");
 		free(bo);
 		bo = dup;
 		goto unlock;
@@ -636,8 +734,11 @@ int drm_tegra_bo_from_dmabuf(struct drm_tegra_bo **bop, struct drm_tegra *drm,
 
 	/* handle lseek() error */
 	if (err) {
+		VDBG_BO(bo, "lseek failed %d (%s)\n", err, strerror(-err));
 		drm_tegra_bo_free(bo);
 		bo = NULL;
+	} else {
+		DBG_BO(bo, "success\n");
 	}
 
 unlock:
@@ -664,6 +765,8 @@ int drm_tegra_bo_forbid_caching(struct drm_tegra_bo *bo)
 		return -EINVAL;
 
 	bo->reuse = false;
+
+	DBG_BO(bo, "\n");
 
 	return 0;
 }

--- a/tegra/tegra.c
+++ b/tegra/tegra.c
@@ -57,6 +57,134 @@ static struct drm_tegra_bo * lookup_bo(void *table, uint32_t key)
 	return bo;
 }
 
+static void drm_tegra_bo_setup_guards(struct drm_tegra_bo *bo)
+{
+	struct drm_tegra *drm = bo->drm;
+	struct drm_tegra_gem_mmap args;
+	uint64_t guard = 0x5351317315731757;
+	uint8_t *map;
+	size_t size;
+	unsigned i;
+	int err;
+
+	if (!drm->debug_bo_front_guard && !drm->debug_bo_back_guard)
+		return;
+
+	size = bo->size;
+
+	if (drm->debug_bo_back_guard)
+		size += 4096;
+
+	memset(&args, 0, sizeof(args));
+	args.handle = bo->handle;
+
+	err = drmCommandWriteRead(drm->fd, DRM_TEGRA_GEM_MMAP,
+				  &args, sizeof(args));
+	if (err < 0) {
+		VDBG_BO(bo, "failed get mapping offset err %d (%s)\n",
+			err, strerror(-err));
+		abort();
+	}
+
+	map = mmap(0, bo->offset + size, PROT_READ | PROT_WRITE, MAP_SHARED,
+		   drm->fd, args.offset);
+	if (map == MAP_FAILED) {
+		VDBG_BO(bo, "failed to map guard 0x%llX err %d (%s)\n",
+			args.offset, -errno, strerror(errno));
+		abort();
+	}
+
+	if (drm->debug_bo_front_guard)
+		bo->guard_front = (uint64_t *)map;
+
+	if (drm->debug_bo_back_guard)
+		bo->guard_back = (uint64_t *)(map + bo->offset + bo->size);
+
+	VDBG_BO(bo, "front %p back %p\n", bo->guard_front, bo->guard_back);
+
+	/* we only interested in guards mapping, hence unmap the actual BO */
+	if (bo->size >= 4096)
+		munmap(map + bo->offset, align(bo->size - 4095, 4096));
+
+	if (bo->handle & 1)
+		guard = ~guard;
+
+	if (drm->debug_bo_front_guard)
+		for (i = 0; i < 512; i++)
+			bo->guard_front[i] = guard;
+
+	if (drm->debug_bo_back_guard)
+		for (i = 0; i < 512; i++)
+			bo->guard_back[i] = guard;
+}
+
+static void drm_tegra_bo_check_guards(struct drm_tegra_bo *bo)
+{
+	struct drm_tegra *drm = bo->drm;
+	uint64_t guard_check = 0x5351317315731757;
+	uint64_t guard;
+	unsigned i;
+
+	if (!drm->debug_bo_front_guard && !drm->debug_bo_back_guard)
+		return;
+
+	VDBG_BO(bo, "front %p back %p\n", bo->guard_front, bo->guard_back);
+
+	if (bo->handle & 1)
+		guard_check = ~guard_check;
+
+	if (drm->debug_bo_front_guard) {
+		for (i = 0; i < 512; i++) {
+			guard = bo->guard_front[i];
+
+			if (guard != guard_check) {
+				VDBG_BO(bo, "front guard is corrupted: entry %u is 0x%16llX, should be 0x%16llX\n",
+					i, guard, guard_check);
+				abort();
+			}
+		}
+	}
+
+	if (drm->debug_bo_back_guard) {
+		for (i = 0; i < 512; i++) {
+			guard = bo->guard_back[i];
+
+			if (guard != guard_check) {
+				VDBG_BO(bo, "back guard is corrupted: entry %u is 0x%16llX, should be 0x%16llX\n",
+					i, guard, guard_check);
+				abort();
+			}
+		}
+	}
+}
+
+static void drm_tegra_bo_unmap_guards(struct drm_tegra_bo *bo)
+{
+	unsigned long unaligned = (unsigned long)bo->guard_back;
+	unsigned long aligned = align(unaligned - 4095, 4096);
+	void *guard_back = (void *)aligned;
+	unsigned guard_back_size = 4096;
+	struct drm_tegra *drm = bo->drm;
+
+	if (!drm->debug_bo_front_guard && !drm->debug_bo_back_guard)
+		return;
+
+	VDBG_BO(bo, "front %p back %p (%u)\n",
+		bo->guard_front, guard_back, guard_back_size);
+
+	if (bo->size & 4095)
+		guard_back_size *= 2;
+
+	if (drm->debug_bo_front_guard)
+		munmap(bo->guard_front, 4096);
+
+	if (drm->debug_bo_back_guard)
+		munmap(guard_back, guard_back_size);
+
+	bo->guard_front = NULL;
+	bo->guard_back = NULL;
+}
+
 drm_private int drm_tegra_bo_free(struct drm_tegra_bo *bo)
 {
 	struct drm_tegra *drm = bo->drm;
@@ -69,6 +197,8 @@ drm_private int drm_tegra_bo_free(struct drm_tegra_bo *bo)
 		drm->debug_bos_allocated--;
 		drm->debug_bos_total_size -= bo->debug_size;
 	}
+
+	drm_tegra_bo_unmap_guards(bo);
 
 	if (bo->map) {
 		if (RUNNING_ON_VALGRIND)
@@ -143,6 +273,12 @@ static int drm_tegra_wrap(struct drm_tegra **drmp, int fd, bool close)
 	str = getenv("LIBDRM_TEGRA_DEBUG_BO");
 	drm->debug_bo = (str && strcmp(str, "1") == 0);
 
+	str = getenv("LIBDRM_TEGRA_DEBUG_BO_BACK_GUARD");
+	drm->debug_bo_back_guard = (str && strcmp(str, "1") == 0);
+
+	str = getenv("LIBDRM_TEGRA_DEBUG_BO_FRONT_GUARD");
+	drm->debug_bo_front_guard = (str && strcmp(str, "1") == 0);
+
 	*drmp = drm;
 
 	return 0;
@@ -215,6 +351,14 @@ int drm_tegra_bo_new(struct drm_tegra_bo **bop, struct drm_tegra *drm,
 	args.flags = flags;
 	args.size = size;
 
+	if (drm->debug_bo_front_guard) {
+		bo->offset += 4096;
+		args.size += 4096;
+	}
+
+	if (drm->debug_bo_back_guard)
+		args.size += 4096;
+
 	err = drmCommandWriteRead(drm->fd, DRM_TEGRA_GEM_CREATE, &args,
 				  sizeof(args));
 	if (err < 0) {
@@ -235,6 +379,7 @@ int drm_tegra_bo_new(struct drm_tegra_bo **bop, struct drm_tegra *drm,
 		drm->debug_bos_allocated++;
 	}
 
+	drm_tegra_bo_setup_guards(bo);
 	DBG_BO_STATS(drm);
 
 	pthread_mutex_lock(&table_lock);
@@ -313,6 +458,8 @@ int drm_tegra_bo_unref(struct drm_tegra_bo *bo)
 
 	if (!atomic_dec_and_test(&bo->ref))
 		return 0;
+
+	drm_tegra_bo_check_guards(bo);
 
 	pthread_mutex_lock(&table_lock);
 

--- a/tegra/tegra.c
+++ b/tegra/tegra.c
@@ -59,6 +59,7 @@ static struct drm_tegra_bo * lookup_bo(void *table, uint32_t key)
 
 static void drm_tegra_bo_setup_guards(struct drm_tegra_bo *bo)
 {
+#ifndef NDEBUG
 	struct drm_tegra *drm = bo->drm;
 	struct drm_tegra_gem_mmap args;
 	uint64_t guard = 0x5351317315731757;
@@ -116,10 +117,12 @@ static void drm_tegra_bo_setup_guards(struct drm_tegra_bo *bo)
 	if (drm->debug_bo_back_guard)
 		for (i = 0; i < 512; i++)
 			bo->guard_back[i] = guard;
+#endif
 }
 
 static void drm_tegra_bo_check_guards(struct drm_tegra_bo *bo)
 {
+#ifndef NDEBUG
 	struct drm_tegra *drm = bo->drm;
 	uint64_t guard_check = 0x5351317315731757;
 	uint64_t guard;
@@ -156,10 +159,12 @@ static void drm_tegra_bo_check_guards(struct drm_tegra_bo *bo)
 			}
 		}
 	}
+#endif
 }
 
 static void drm_tegra_bo_unmap_guards(struct drm_tegra_bo *bo)
 {
+#ifndef NDEBUG
 	unsigned long unaligned = (unsigned long)bo->guard_back;
 	unsigned long aligned = align(unaligned - 4095, 4096);
 	void *guard_back = (void *)aligned;
@@ -183,6 +188,7 @@ static void drm_tegra_bo_unmap_guards(struct drm_tegra_bo *bo)
 
 	bo->guard_front = NULL;
 	bo->guard_back = NULL;
+#endif
 }
 
 drm_private int drm_tegra_bo_free(struct drm_tegra_bo *bo)
@@ -193,11 +199,12 @@ drm_private int drm_tegra_bo_free(struct drm_tegra_bo *bo)
 
 	DBG_BO(bo, "\n");
 
+#ifndef NDEBUG
 	if (drm->debug_bo) {
 		drm->debug_bos_allocated--;
 		drm->debug_bos_total_size -= bo->debug_size;
 	}
-
+#endif
 	drm_tegra_bo_unmap_guards(bo);
 
 	if (bo->map) {
@@ -211,20 +218,22 @@ drm_private int drm_tegra_bo_free(struct drm_tegra_bo *bo)
 			munmap(bo->map_cached, bo->offset + bo->size);
 
 		DRMLISTDEL(&bo->mmap_list);
-
+#ifndef NDEBUG
 		if (drm->debug_bo) {
 			drm->debug_bos_mappings_cached--;
 			drm->debug_bos_cached_pages -= bo->debug_size / 4096;
 		}
+#endif
 	} else {
 		goto vg_free;
 	}
 
+#ifndef NDEBUG
 	if (drm->debug_bo) {
 		drm->debug_bos_mapped--;
 		drm->debug_bos_total_pages -= bo->debug_size / 4096;
 	}
-
+#endif
 vg_free:
 	VG_BO_FREE(bo);
 
@@ -247,10 +256,25 @@ vg_free:
 	return err;
 }
 
+static void drm_tegra_setup_debug(struct drm_tegra *drm)
+{
+#ifndef NDEBUG
+	char *str;
+
+	str = getenv("LIBDRM_TEGRA_DEBUG_BO");
+	drm->debug_bo = (str && strcmp(str, "1") == 0);
+
+	str = getenv("LIBDRM_TEGRA_DEBUG_BO_BACK_GUARD");
+	drm->debug_bo_back_guard = (str && strcmp(str, "1") == 0);
+
+	str = getenv("LIBDRM_TEGRA_DEBUG_BO_FRONT_GUARD");
+	drm->debug_bo_front_guard = (str && strcmp(str, "1") == 0);
+#endif
+}
+
 static int drm_tegra_wrap(struct drm_tegra **drmp, int fd, bool close)
 {
 	struct drm_tegra *drm;
-	char *str;
 
 	if (fd < 0 || !drmp)
 		return -EINVAL;
@@ -270,14 +294,7 @@ static int drm_tegra_wrap(struct drm_tegra **drmp, int fd, bool close)
 	if (!drm->handle_table || !drm->name_table)
 		return -ENOMEM;
 
-	str = getenv("LIBDRM_TEGRA_DEBUG_BO");
-	drm->debug_bo = (str && strcmp(str, "1") == 0);
-
-	str = getenv("LIBDRM_TEGRA_DEBUG_BO_BACK_GUARD");
-	drm->debug_bo_back_guard = (str && strcmp(str, "1") == 0);
-
-	str = getenv("LIBDRM_TEGRA_DEBUG_BO_FRONT_GUARD");
-	drm->debug_bo_front_guard = (str && strcmp(str, "1") == 0);
+	drm_tegra_setup_debug(drm);
 
 	*drmp = drm;
 
@@ -351,6 +368,7 @@ int drm_tegra_bo_new(struct drm_tegra_bo **bop, struct drm_tegra *drm,
 	args.flags = flags;
 	args.size = size;
 
+#ifndef NDEBUG
 	if (drm->debug_bo_front_guard) {
 		bo->offset += 4096;
 		args.size += 4096;
@@ -358,7 +376,7 @@ int drm_tegra_bo_new(struct drm_tegra_bo **bop, struct drm_tegra *drm,
 
 	if (drm->debug_bo_back_guard)
 		args.size += 4096;
-
+#endif
 	err = drmCommandWriteRead(drm->fd, DRM_TEGRA_GEM_CREATE, &args,
 				  sizeof(args));
 	if (err < 0) {
@@ -373,12 +391,13 @@ int drm_tegra_bo_new(struct drm_tegra_bo **bop, struct drm_tegra *drm,
 	DBG_BO(bo, "success new\n");
 	VG_BO_ALLOC(bo);
 
+#ifndef NDEBUG
 	if (drm->debug_bo) {
 		bo->debug_size = align(bo->size, 4096);
 		drm->debug_bos_total_size += bo->debug_size;
 		drm->debug_bos_allocated++;
 	}
-
+#endif
 	drm_tegra_bo_setup_guards(bo);
 	DBG_BO_STATS(drm);
 
@@ -525,11 +544,12 @@ drm_private int __drm_tegra_bo_map(struct drm_tegra_bo *bo, void **ptr)
 out:
 	*ptr = map;
 
+#ifndef NDEBUG
 	if (drm->debug_bo && ptr == &bo->map) {
 		drm->debug_bos_mapped++;
 		drm->debug_bos_total_pages += bo->debug_size / 4096;
 	}
-
+#endif
 	DBG_BO(bo, "success\n");
 	DBG_BO_STATS(drm);
 

--- a/tegra/tegra_bo_cache.c
+++ b/tegra/tegra_bo_cache.c
@@ -107,9 +107,10 @@ drm_tegra_bo_cache_cleanup(struct drm_tegra *drm,
 			VG_BO_OBTAIN(bo);
 			DRMLISTDEL(&bo->bo_list);
 			drm_tegra_bo_free(bo);
-
+#ifndef NDEBUG
 			if (drm->debug_bo)
 				drm->debug_bos_cached--;
+#endif
 		}
 	}
 
@@ -248,12 +249,12 @@ drm_tegra_bo_cache_free(struct drm_tegra_bo *bo)
 		VG_BO_RELEASE(bo);
 		drm_tegra_bo_cache_cleanup(drm, time.tv_sec);
 		DRMLISTADDTAIL(&bo->bo_list, &bucket->list);
-
+#ifndef NDEBUG
 		if (drm->debug_bo) {
 			drm->debug_bos_cached++;
 			DBG_BO_STATS(drm);
 		}
-
+#endif
 		return 0;
 	}
 
@@ -283,13 +284,14 @@ drm_tegra_bo_mmap_cache_cleanup(struct drm_tegra *drm,
 
 		DRMLISTDEL(&bo->mmap_list);
 		bo->map_cached = NULL;
-
+#ifndef NDEBUG
 		if (drm->debug_bo) {
 			drm->debug_bos_mapped--;
 			drm->debug_bos_mappings_cached--;
 			drm->debug_bos_total_pages -= bo->debug_size / 4096;
 			drm->debug_bos_cached_pages -= bo->debug_size / 4096;
 		}
+#endif
 	}
 
 	cache->time = time;
@@ -309,12 +311,12 @@ drm_tegra_bo_cache_unmap(struct drm_tegra_bo *bo)
 
 	drm_tegra_bo_mmap_cache_cleanup(drm, cache, time.tv_sec);
 	DRMLISTADDTAIL(&bo->mmap_list, &cache->list);
-
+#ifndef NDEBUG
 	if (drm->debug_bo) {
 		drm->debug_bos_mappings_cached++;
 		drm->debug_bos_cached_pages += bo->debug_size / 4096;
 	}
-
+#endif
 	DBG_BO(bo, "mapping added to cache\n");
 	DBG_BO_STATS(drm);
 }
@@ -322,17 +324,20 @@ drm_tegra_bo_cache_unmap(struct drm_tegra_bo *bo)
 drm_private void *
 drm_tegra_bo_cache_map(struct drm_tegra_bo *bo)
 {
+#ifndef NDEBUG
 	struct drm_tegra *drm = bo->drm;
+#endif
 	void *map_cached = bo->map_cached;
 
 	if (map_cached) {
 		DRMLISTDEL(&bo->mmap_list);
 		bo->map_cached = NULL;
-
+#ifndef NDEBUG
 		if (drm->debug_bo) {
 			drm->debug_bos_mappings_cached--;
 			drm->debug_bos_cached_pages -= bo->debug_size / 4096;
 		}
+#endif
 	}
 
 	return map_cached;


### PR DESCRIPTION
Add some debug messages, which are enabled using LIBDRM_TEGRA_DEBUG_BO env var and add BO integrity checking (similar to what we have in grate) which is enabled by LIBDRM_TEGRA_DEBUG_BO_FRONT_GUARD and LIBDRM_TEGRA_DEBUG_BO_BACK_GUARD env vars. Although for now only the end of BO is verified, because checking the front of BO would require libdrm user to annotate that it is appropriate for a BO and that would be libdrm API change or its extension, I decided to postpone that.