### PR TITLE
tegra: Avoid unnecessary context switches on BO reset

### DIFF
--- a/tegra/private.h
+++ b/tegra/private.h
@@ -114,6 +114,8 @@ struct drm_tegra_bo {
 	time_t unmap_time;		/* time when added to cache-list */
 	void *map_cached;		/* holds cached mmap pointer */
 
+	bool custom_tiling;
+	bool custom_flags;
 };
 
 struct drm_tegra_channel {

--- a/tegra/tegra.c
+++ b/tegra/tegra.c
@@ -419,6 +419,8 @@ int drm_tegra_bo_set_flags(struct drm_tegra_bo *bo, uint32_t flags)
 	if (err < 0)
 		return err;
 
+	bo->custom_flags = (flags != 0);
+
 	return 0;
 }
 
@@ -451,6 +453,7 @@ int drm_tegra_bo_set_tiling(struct drm_tegra_bo *bo,
 			    const struct drm_tegra_bo_tiling *tiling)
 {
 	struct drm_tegra_gem_set_tiling args;
+	int err;
 
 	if (!bo || !tiling)
 		return -EINVAL;
@@ -460,8 +463,14 @@ int drm_tegra_bo_set_tiling(struct drm_tegra_bo *bo,
 	args.mode = tiling->mode;
 	args.value = tiling->value;
 
-	return drmCommandWriteRead(bo->drm->fd, DRM_TEGRA_GEM_SET_TILING,
-				   &args, sizeof(args));
+	err = drmCommandWriteRead(bo->drm->fd, DRM_TEGRA_GEM_SET_TILING,
+				  &args, sizeof(args));
+	if (err < 0)
+		return err;
+
+	bo->custom_tiling = (tiling->mode || tiling->value);
+
+	return 0;
 }
 
 int drm_tegra_bo_get_name(struct drm_tegra_bo *bo, uint32_t *name)

--- a/tegra/tegra_bo_cache.c
+++ b/tegra/tegra_bo_cache.c
@@ -169,14 +169,18 @@ static void reset_bo(struct drm_tegra_bo *bo, uint32_t flags)
 
 	VG_BO_OBTAIN(bo);
 
-	/* XXX: Error handling? */
-	drm_tegra_bo_set_flags(bo, flags);
+	if (bo->custom_flags) {
+		/* XXX: Error handling? */
+		drm_tegra_bo_set_flags(bo, flags);
+	}
 
-	/* reset tiling mode */
-	memset(&tiling, 0, sizeof(tiling));
+	if (bo->custom_tiling) {
+		/* reset tiling mode */
+		memset(&tiling, 0, sizeof(tiling));
 
-	/* XXX: Error handling? */
-	drm_tegra_bo_set_tiling(bo, &tiling);
+		/* XXX: Error handling? */
+		drm_tegra_bo_set_tiling(bo, &tiling);
+	}
 
 	/* reset reference counters */
 	atomic_set(&bo->ref, 1);


### PR DESCRIPTION
Context switching from / to kernel mode isn't super-cheap, let's avoid unnecessary switches on BO reset, which may happen quite often.