### PR TITLE
tegra: Correct cached BO's counting

### DIFF
--- a/tegra/tegra.c
+++ b/tegra/tegra.c
@@ -516,7 +516,7 @@ drm_private int __drm_tegra_bo_map(struct drm_tegra_bo *bo, void **ptr)
 #ifdef HAVE_VALGRIND
 	if (RUNNING_ON_VALGRIND && bo->map_vg) {
 		map = bo->map_vg;
-		goto out;
+		goto map_cnt;
 	}
 #endif
 
@@ -541,9 +541,9 @@ drm_private int __drm_tegra_bo_map(struct drm_tegra_bo *bo, void **ptr)
 	}
 
 	map += bo->offset;
-out:
-	*ptr = map;
-
+#ifdef HAVE_VALGRIND
+map_cnt:
+#endif
 #ifndef NDEBUG
 	if (drm->debug_bo && ptr == &bo->map) {
 		drm->debug_bos_mapped++;
@@ -551,7 +551,11 @@ out:
 	}
 #endif
 	DBG_BO(bo, "success\n");
-	DBG_BO_STATS(drm);
+out:
+	if (ptr == &bo->map)
+		DBG_BO_STATS(drm);
+
+	*ptr = map;
 
 	return 0;
 }

--- a/tegra/tegra_bo_cache.c
+++ b/tegra/tegra_bo_cache.c
@@ -223,6 +223,10 @@ drm_tegra_bo_cache_alloc(struct drm_tegra *drm,
 		bo = find_in_bucket(bucket, flags);
 		if (bo) {
 			reset_bo(bo, flags);
+#ifndef NDEBUG
+			if (drm->debug_bo)
+				drm->debug_bos_cached--;
+#endif
 			return bo;
 		}
 	}


### PR DESCRIPTION
Add missed cached BO's debug number decrement for taken out from cache BO.

Signed-off-by: Dmitry Osipenko <digetx@gmail.com>