### PR TITLE
drm/tegra: Correct formatting of debug messages

### DIFF
--- a/tegra/private.h
+++ b/tegra/private.h
@@ -25,6 +25,7 @@
 #ifndef __DRM_TEGRA_PRIVATE_H__
 #define __DRM_TEGRA_PRIVATE_H__ 1
 
+#include <inttypes.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/tegra/tegra.c
+++ b/tegra/tegra.c
@@ -141,7 +141,7 @@ static void drm_tegra_bo_check_guards(struct drm_tegra_bo *bo)
 			guard = bo->guard_front[i];
 
 			if (guard != guard_check) {
-				VDBG_BO(bo, "front guard is corrupted: entry %u is 0x%16llX, should be 0x%16llX\n",
+				VDBG_BO(bo, "front guard is corrupted: entry %u is 0x%16" PRIX64 ", should be 0x%16" PRIX64 "\n",
 					i, guard, guard_check);
 				abort();
 			}
@@ -153,7 +153,7 @@ static void drm_tegra_bo_check_guards(struct drm_tegra_bo *bo)
 			guard = bo->guard_back[i];
 
 			if (guard != guard_check) {
-				VDBG_BO(bo, "back guard is corrupted: entry %u is 0x%16llX, should be 0x%16llX\n",
+				VDBG_BO(bo, "back guard is corrupted: entry %u is 0x%16" PRIX64 ", should be 0x%16" PRIX64 "\n",
 					i, guard, guard_check);
 				abort();
 			}


### PR DESCRIPTION
Silence compilation warnings for a 64bit target.