### PR TITLE
tegra: Correct other #ifdef HAVE_VALGRIND occurrences in the code

### DIFF
--- a/tegra/private.h
+++ b/tegra/private.h
@@ -160,7 +160,7 @@ struct drm_tegra_bo {
 	uint32_t mmap_ref;
 	void *map;
 
-#ifdef HAVE_VALGRIND
+#if HAVE_VALGRIND
 	void *map_vg;
 #endif
 

--- a/tegra/tegra.c
+++ b/tegra/tegra.c
@@ -513,7 +513,7 @@ drm_private int __drm_tegra_bo_map(struct drm_tegra_bo *bo, void **ptr)
 		goto out;
 	}
 
-#ifdef HAVE_VALGRIND
+#if HAVE_VALGRIND
 	if (RUNNING_ON_VALGRIND && bo->map_vg) {
 		map = bo->map_vg;
 		goto map_cnt;
@@ -541,7 +541,7 @@ drm_private int __drm_tegra_bo_map(struct drm_tegra_bo *bo, void **ptr)
 	}
 
 	map += bo->offset;
-#ifdef HAVE_VALGRIND
+#if HAVE_VALGRIND
 map_cnt:
 #endif
 #ifndef NDEBUG


### PR DESCRIPTION
This is a followup to the patch that fixed building with valgrind not being installed in the system.