### PR TITLE
Better caching

### DIFF
--- a/tegra/private.h
+++ b/tegra/private.h
@@ -104,6 +104,8 @@ enum host1x_class {
 struct drm_tegra_bo_bucket {
 	uint32_t size;
 	drmMMListHead list;
+	uint32_t num_entries;
+	uint32_t num_mmap_entries;
 };
 
 struct drm_tegra_bo_cache {
@@ -177,7 +179,6 @@ struct drm_tegra_bo {
 	void *map_cached;		/* holds cached mmap pointer */
 
 	bool custom_tiling;
-	bool custom_flags;
 
 #ifndef NDEBUG
 	uint32_t debug_size;
@@ -250,6 +251,12 @@ struct drm_tegra_bo * drm_tegra_bo_cache_alloc(struct drm_tegra *drm,
 int drm_tegra_bo_cache_free(struct drm_tegra_bo *bo);
 void drm_tegra_bo_cache_unmap(struct drm_tegra_bo *bo);
 void *drm_tegra_bo_cache_map(struct drm_tegra_bo *bo);
+
+struct drm_tegra_bo_bucket *
+drm_tegra_get_bucket(struct drm_tegra *drm, uint32_t size);
+
+void drm_tegra_reset_bo(struct drm_tegra_bo *bo, uint32_t flags,
+			bool set_flags);
 
 #if HAVE_VALGRIND
 #  include <memcheck.h>

--- a/tegra/tegra.c
+++ b/tegra/tegra.c
@@ -34,7 +34,7 @@
 
 #include "private.h"
 
-drm_private pthread_mutex_t table_lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t table_lock = PTHREAD_MUTEX_INITIALIZER;
 
 /* lookup a buffer, call with table_lock mutex locked */
 static struct drm_tegra_bo * lookup_bo(void *table, uint32_t key)
@@ -345,7 +345,10 @@ drm_public int drm_tegra_bo_new(struct drm_tegra_bo **bop, struct drm_tegra *drm
 	if (!drm || size == 0 || !bop)
 		return -EINVAL;
 
+	pthread_mutex_lock(&table_lock);
 	bo = drm_tegra_bo_cache_alloc(drm, &size, flags);
+	pthread_mutex_unlock(&table_lock);
+
 	if (bo) {
 		DBG_BO(bo, "success from cache\n");
 		goto out;

--- a/tegra/tegra_bo_cache.c
+++ b/tegra/tegra_bo_cache.c
@@ -34,8 +34,6 @@
 
 #include "private.h"
 
-drm_private extern pthread_mutex_t table_lock;
-
 static void
 add_bucket(struct drm_tegra_bo_cache *cache, int size)
 {
@@ -217,8 +215,6 @@ drm_tegra_bo_cache_alloc(struct drm_tegra *drm,
 
 	/* see if we can be green and recycle: */
 	if (bucket) {
-		pthread_mutex_lock(&table_lock);
-
 		*size = bucket->size;
 		bo = find_in_bucket(bucket, flags);
 		if (bo) {
@@ -228,8 +224,6 @@ drm_tegra_bo_cache_alloc(struct drm_tegra *drm,
 				drm->debug_bos_cached--;
 #endif
 		}
-
-		pthread_mutex_unlock(&table_lock);
 	}
 
 	return bo;


### PR DESCRIPTION
Here is a small improvement to the BO-caching strategy that defers BO releasing if cache-bucket is nearly empty, this should reduce the number of unnecessary re-allocations a tad.